### PR TITLE
Fixed file separator when accessing zip

### DIFF
--- a/src/Codec/Xlsx/Parser.hs
+++ b/src/Codec/Xlsx/Parser.hs
@@ -173,7 +173,7 @@ getWorksheetFiles ar = case xmlCursor ar "xl/workbook.xml" of
         sheetData = c $/ element (n"sheets") &/ element (n"sheet") >=>
                     liftA2 (,) <$> attribute "name" <*> attribute (odr"id")
         wbRels = getWbRels ar
-    in [WorksheetFile name ("xl" </> T.unpack (fromJust $ lookup rId wbRels)) | (name, rId) <- sheetData]
+    in [WorksheetFile name ("xl/" ++ T.unpack (fromJust $ lookup rId wbRels)) | (name, rId) <- sheetData]
 
 getWbRels :: Zip.Archive -> [(Text, Text)]
 getWbRels ar = case xmlCursor ar "xl/_rels/workbook.xml.rels" of


### PR DESCRIPTION
The "x" </> "y"  operator in windows system makes a "x\y" string, but the contents of the zip are all loaded in "x/y" style.
