### PR TITLE
Parse formatted cell values

### DIFF
--- a/src/Codec/Xlsx/Parser.hs
+++ b/src/Codec/Xlsx/Parser.hs
@@ -152,7 +152,7 @@ xmlCursor ar fname = parse <$> Zip.findEntryByPath fname ar
         Left _  -> error "could not read file"
         Right d -> fromDocument d
 
-  -- | Get shared strings (if there are some) into IntMap.
+-- | Get shared strings (if there are some) into IntMap.
 getSharedStrings  :: Zip.Archive -> IM.IntMap Text
 getSharedStrings x = case xmlCursor x "xl/sharedStrings.xml" of
     Nothing  -> IM.empty


### PR DESCRIPTION
- Enhancement -
If a cell's value contains formatting (e.g. bold the first character(s), underline a word) the 'sharedStrings.xml' file will contain additional markup. Currently these tags are not parsed which skews the indexing when shared strings are then read by Codec.Xlsx.Parser.extractSheet resulting in broken correspondence between values and row/column addresses. This change parses these extra tags and preserves the order of the Codec.Xlsx.Parser.toXlsx.ss list and the source xlsx/sharedStrings.xml file.

Note: This implementation depends on <si> tags containing either <t> -OR- <r> <t> tags which seems to hold in my testing.
