### PR TITLE
Add support for defined names

### DIFF
--- a/src/Test.hs
+++ b/src/Test.hs
@@ -87,7 +87,7 @@ styles = Styles "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\
 main :: IO ()
 main =  do
     ct <- getClockTime
-    L.writeFile "test.xlsx" $ fromXlsx ct $ Xlsx sheets styles
+    L.writeFile "test.xlsx" $ fromXlsx ct $ Xlsx sheets styles def
     x <- toXlsx <$> L.readFile "test.xlsx"
     putStrLn $ "And cell (3,2) value in list 'List' is " ++
              show (x ^? xlSheets . ix "List" . wsCells . ix (3,2) . cellValue . _Just)

--- a/test/DataTest.hs
+++ b/test/DataTest.hs
@@ -34,7 +34,7 @@ main = defaultMain $
     ]
 
 testXlsx :: Xlsx
-testXlsx = Xlsx sheets emptyStyles
+testXlsx = Xlsx sheets emptyStyles def
   where
     sheets = M.fromList [( "List1", sheet )]
     sheet = Worksheet cols rowProps testCellMap []


### PR DESCRIPTION
This adds a fairly low-level feature: a workbook can have an associated set of "defined names" (Section 18.2.6, "definedNames (Defined Names)" (p. 1728) of the spec). This is primarily useful (for me anyway) to specify which columns/headers should be repeated on every page when printing. 

Submitting this as a separate PR because it adds some stuff relatively deep down the type stack. Implemented both a parser and a renderer, although this is only a partial implementation of defined names (only the essential properties of defined names are currently supported). 