### PR TITLE
Fix :bug: <t> without child node omitted

### DIFF
--- a/src/Codec/Xlsx/Types/SharedStringTable.hs
+++ b/src/Codec/Xlsx/Types/SharedStringTable.hs
@@ -130,7 +130,8 @@ instance FromCursor SharedStringTable where
 instance FromCursor StringItem where
   fromCursor cur = do
     let
-      ts = cur $/ element (n"t") &/ content
+      tcs = cur $/ element (n"t")
+      ts = map getFirstText tcs
       rs = cur $/ element (n"r") >=> fromCursor
     case (ts,rs) of
       ([t], []) ->
@@ -139,6 +140,13 @@ instance FromCursor StringItem where
         return $ StringItemRich rs
       _ ->
         fail "invalid item"
+    where
+      getFirstText :: Cursor -> Text
+      getFirstText c =
+          case c $/ content of
+               [t] -> t
+               []  -> ""
+               _   -> error "invalid item: more than one text nodes under <t>!"
 
 {-------------------------------------------------------------------------------
   Extract shared strings

--- a/test/DataTest.hs
+++ b/test/DataTest.hs
@@ -34,6 +34,8 @@ main = defaultMain $
          testStyleSheet @=? fromRight (parseStyleSheet (renderStyleSheet  testStyleSheet))
     , testCase "correct shared strings parsing" $
          [testSharedStringTable] @=? testParsedSharedStringTables
+    , testCase "correct shared strings parsing even when one of the shared strings entry is just <t/>" $
+         [testSharedStringTableWithEmpty] @=? testParsedSharedStringTablesWithEmpty
     ]
 
 testXlsx :: Xlsx
@@ -87,6 +89,7 @@ testSharedStringTable = SharedStringTable $ V.fromList items
   where
     items = [text, rich]
     text = StringItemText "plain text"
+    empty = StringItemText ""
     rich = StringItemRich [ RichTextRun Nothing "Just "
                           , RichTextRun (Just props) "example" ]
     props = def & runPropertiesBold .~ Just True
@@ -95,8 +98,15 @@ testSharedStringTable = SharedStringTable $ V.fromList items
                 & runPropertiesFont .~ Just "Arial"
                 & runPropertiesFontFamily .~ Just FontFamilySwiss
 
+testSharedStringTableWithEmpty :: SharedStringTable
+testSharedStringTableWithEmpty =
+  SharedStringTable $ V.fromList [StringItemText ""]
+
 testParsedSharedStringTables ::[SharedStringTable]
 testParsedSharedStringTables = fromCursor . fromDocument $ parseLBS_ def testStrings
+
+testParsedSharedStringTablesWithEmpty :: [SharedStringTable]
+testParsedSharedStringTablesWithEmpty = fromCursor . fromDocument $ parseLBS_ def testStringsWithEmpty
 
 testStrings :: ByteString
 testStrings = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\
@@ -104,4 +114,10 @@ testStrings = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\
   \<si><t>plain text</t></si>\
   \<si><r><t>Just </t></r><r><rPr><b val=\"true\"/><u val=\"single\"/>\
   \<sz val=\"10\"/><rFont val=\"Arial\"/><family val=\"2\"/></rPr><t>example</t></r></si>\
+  \</sst>"
+
+testStringsWithEmpty :: ByteString
+testStringsWithEmpty = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\
+  \<sst xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" count=\"2\" uniqueCount=\"2\">\
+  \<si><t/></si>\
   \</sst>"


### PR DESCRIPTION
# Problem

I'm not sure why, but I found a case where Excel writes a weird `<t/>`
element in the sharedStrings.xml like this:

```xml
...
<si><t/></si>
...
```

And Excel shows a cell referring the sharedStrings entry as an empty cell (as you might
expect).
But the current `SharedStringTable` module can't handle such a case correctly.

# Solution

Handle `<t>` without any child node as `StringItemText ""`