### PR TITLE
Catch parsing errors and report them through toXlsxEither function

### DIFF
--- a/src/Codec/Xlsx/Parser.hs
+++ b/src/Codec/Xlsx/Parser.hs
@@ -23,6 +23,7 @@ import           Data.Ord
 import           Data.Text                                   (Text)
 import qualified Data.Text                                   as T
 import qualified Data.Text.Read                              as T
+import           Data.Traversable
 import           Prelude                                     hiding (sequence)
 import           Safe
 import           System.FilePath.Posix

--- a/src/Codec/Xlsx/Parser.hs
+++ b/src/Codec/Xlsx/Parser.hs
@@ -1,15 +1,19 @@
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE NoMonomorphismRestriction #-}
 {-# LANGUAGE OverloadedStrings         #-}
 {-# LANGUAGE TupleSections             #-}
 -- | This module provides a function for reading .xlsx files
 module Codec.Xlsx.Parser
     ( toXlsx
+    , toXlsxEither
+    , ParseError (..)
     ) where
 
 import qualified Codec.Archive.Zip                           as Zip
 import           Control.Applicative
 import           Control.Arrow                               ((&&&))
 import           Control.Monad.IO.Class                      ()
+import           Data.Bifunctor                              (bimap, first)
 import qualified Data.ByteString.Lazy                        as L
 import           Data.ByteString.Lazy.Char8                  ()
 import           Data.List
@@ -37,14 +41,22 @@ import           Codec.Xlsx.Types.Internal.SharedStringTable
 
 -- | Reads `Xlsx' from raw data (lazy bytestring)
 toXlsx :: L.ByteString -> Xlsx
-toXlsx bs = Xlsx sheets styles names customPropMap
-  where
-    ar = Zip.toArchive bs
-    sst = getSharedStrings ar
-    styles = getStyles ar
-    (wfs, names) = readWorkbook ar
-    sheets = M.fromList $ map (wfName &&& extractSheet ar sst) wfs
-    CustomProperties customPropMap = getCustomProperties ar
+toXlsx = either (error . show) id . toXlsxEither
+
+data ParseError = InvalidZipArchive
+                | MissingFile FilePath
+                | InvalidFile FilePath
+                deriving (Show, Eq)
+
+-- | Reads `Xlsx' from raw data (lazy bytestring), failing with Left on parse error
+toXlsxEither :: L.ByteString -> Either ParseError Xlsx
+toXlsxEither bs = do
+  ar <- first (const InvalidZipArchive) $ Zip.toArchiveOrFail bs
+  sst <- getSharedStrings ar
+  (wfs, names) <- readWorkbook ar
+  sheets <- sequenceA . M.fromList $ map (wfName &&& extractSheet ar sst) wfs
+  CustomProperties customPropMap <- getCustomProperties ar
+  return $ Xlsx sheets (getStyles ar) names customPropMap
 
 data WorksheetFile = WorksheetFile { wfName :: Text
                                    , wfPath :: FilePath
@@ -54,68 +66,68 @@ data WorksheetFile = WorksheetFile { wfName :: Text
 extractSheet :: Zip.Archive
              -> SharedStringTable
              -> WorksheetFile
-             -> Worksheet
-extractSheet ar sst wf = Worksheet cws rowProps cells merges sheetViews pageSetup condFormtattings
-  where
-    file = fromJust $ Zip.fromEntry <$> Zip.findEntryByPath (wfPath wf) ar
-    cur = case parseLBS def file of
-      Left _  -> error "could not read file"
-      Right d -> fromDocument d
+             -> Either ParseError Worksheet
+extractSheet ar sst wf = do
+  let  file = fromJust $ Zip.fromEntry <$> Zip.findEntryByPath (wfPath wf) ar
+  cur <- bimap (const $ MissingFile (wfPath wf)) fromDocument $ parseLBS def file
+  sheetRels <- getRels ar (wfPath wf)
 
-    -- The specification says the file should contain either 0 or 1 @sheetViews@
-    -- (4th edition, section 18.3.1.88, p. 1704 and definition CT_Worksheet, p. 3910)
-    sheetViewList = cur $/ element (n"sheetViews") &/ element (n"sheetView") >=> fromCursor
-    sheetViews = case sheetViewList of
-      [] -> Nothing
-      views -> Just views
+  -- The specification says the file should contain either 0 or 1 @sheetViews@
+  -- (4th edition, section 18.3.1.88, p. 1704 and definition CT_Worksheet, p. 3910)
+  let  sheetViewList = cur $/ element (n"sheetViews") &/ element (n"sheetView") >=> fromCursor
+       sheetViews = case sheetViewList of
+         [] -> Nothing
+         views -> Just views
 
-    commentsMap = getComments ar . relTarget =<< findRelByType commentsType sheetRels
-    commentsType = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/comments"
+  let commentsType = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/comments"
+      commentTarget :: Maybe FilePath
+      commentTarget = relTarget <$> findRelByType commentsType sheetRels
 
-    sheetRels = getRels ar (wfPath wf)
+  commentsMap :: Maybe CommentTable <- maybe (Right Nothing) (getComments ar) commentTarget --  getComments ar <$> commentTarget
 
-    -- Likewise, @pageSetup@ also occurs either 0 or 1 times
-    pageSetup = listToMaybe $ cur $/ element (n"pageSetup") >=> fromCursor
+        -- Likewise, @pageSetup@ also occurs either 0 or 1 times
+  let pageSetup = listToMaybe $ cur $/ element (n"pageSetup") >=> fromCursor
 
-    cws = cur $/ element (n"cols") &/ element (n"col") >=> fromCursor
+      cws = cur $/ element (n"cols") &/ element (n"col") >=> fromCursor
 
-    (rowProps, cells) = collect $ cur $/ element (n"sheetData") &/ element (n"row") >=> parseRow
-    parseRow c = do
-      r <- c $| attribute "r" >=> decimal
-      let ht = if attribute "customHeight" c == ["true"]
-               then listToMaybe $ c $| attribute "ht" >=> rational
-               else Nothing
-      let s = if attribute "s" c /= []
-              then listToMaybe $ c $| attribute "s" >=> decimal
-              else Nothing
-      let rp = if isNothing s && isNothing ht
-               then  Nothing
-               else  Just (RowProps ht s)
-      return (r, rp, c $/ element (n"c") >=> parseCell)
-    parseCell :: Cursor -> [(Int, Int, Cell)]
-    parseCell cell = do
-      ref <- cell $| attribute "r"
-      let
-        s = listToMaybe $ cell $| attribute "s" >=> decimal
-        t = fromMaybe "n" $ listToMaybe $ cell $| attribute "t"
-        d = listToMaybe $ cell $/ element (n"v") &/ content >=> extractCellValue sst t
-        f = listToMaybe $ cell $/ element (n"f") >=> fromCursor
-        (c, r) = T.span (>'9') ref
-        comment = commentsMap >>= lookupComment ref
-      return (int r, col2int c, Cell s d comment f)
-    collect = foldr collectRow (M.empty, M.empty)
-    collectRow (_, Nothing, rowCells) (rowMap, cellMap) =
-      (rowMap, foldr collectCell cellMap rowCells)
-    collectRow (r, Just h, rowCells) (rowMap, cellMap) =
-      (M.insert r h rowMap, foldr collectCell cellMap rowCells)
-    collectCell (x, y, cd) = M.insert (x,y) cd
+      (rowProps, cells) = collect $ cur $/ element (n"sheetData") &/ element (n"row") >=> parseRow
+      parseRow c = do
+        r <- c $| attribute "r" >=> decimal
+        let ht = if attribute "customHeight" c == ["true"]
+                 then listToMaybe $ c $| attribute "ht" >=> rational
+                 else Nothing
+        let s = if attribute "s" c /= []
+                then listToMaybe $ c $| attribute "s" >=> decimal
+                else Nothing
+        let rp = if isNothing s && isNothing ht
+                 then  Nothing
+                 else  Just (RowProps ht s)
+        return (r, rp, c $/ element (n"c") >=> parseCell)
+      parseCell :: Cursor -> [(Int, Int, Cell)]
+      parseCell cell = do
+        ref <- cell $| attribute "r"
+        let
+          s = listToMaybe $ cell $| attribute "s" >=> decimal
+          t = fromMaybe "n" $ listToMaybe $ cell $| attribute "t"
+          d = listToMaybe $ cell $/ element (n"v") &/ content >=> extractCellValue sst t
+          f = listToMaybe $ cell $/ element (n"f") >=> fromCursor
+          (c, r) = T.span (>'9') ref
+          comment = commentsMap >>= lookupComment ref
+        return (int r, col2int c, Cell s d comment f)
+      collect = foldr collectRow (M.empty, M.empty)
+      collectRow (_, Nothing, rowCells) (rowMap, cellMap) =
+        (rowMap, foldr collectCell cellMap rowCells)
+      collectRow (r, Just h, rowCells) (rowMap, cellMap) =
+        (M.insert r h rowMap, foldr collectCell cellMap rowCells)
+      collectCell (x, y, cd) = M.insert (x,y) cd
 
-    merges = cur $/ parseMerges
-    parseMerges :: Cursor -> [Text]
-    parseMerges = element (n"mergeCells") &/ element (n"mergeCell") >=> parseMerge
-    parseMerge c = c $| attribute "ref"
+      merges = cur $/ parseMerges
+      parseMerges :: Cursor -> [Text]
+      parseMerges = element (n"mergeCells") &/ element (n"mergeCell") >=> parseMerge
+      parseMerge c = c $| attribute "ref"
 
-    condFormtattings = M.fromList . map unCfPair  $ cur $/ element (n"conditionalFormatting") >=> fromCursor
+      condFormtattings = M.fromList . map unCfPair  $ cur $/ element (n"conditionalFormatting") >=> fromCursor
+  return $ Worksheet cws rowProps cells merges sheetViews pageSetup condFormtattings
 
 extractCellValue :: SharedStringTable -> Text -> Text -> [CellValue]
 extractCellValue sst "s" v =
@@ -136,69 +148,60 @@ extractCellValue _ "b" "0" = [CellBool False]
 extractCellValue _ _ _ = []
 
 -- | Get xml cursor from the specified file inside the zip archive.
-xmlCursor :: Zip.Archive -> FilePath -> Maybe Cursor
-xmlCursor ar fname = parse <$> Zip.findEntryByPath fname ar
+xmlCursor :: Zip.Archive -> FilePath -> Either ParseError (Maybe Cursor)
+xmlCursor ar fname = maybe (Right Nothing) parse $ Zip.findEntryByPath fname ar
   where
-    parse entry = case parseLBS def (Zip.fromEntry entry) of
-        Left _  -> error "could not read file"
-        Right d -> fromDocument d
+    parse entry = bimap (const $ InvalidFile fname) (return . fromDocument) $ parseLBS def (Zip.fromEntry entry)
+
+-- | Get xml cursor from the given file, failing with MissingFile if not found.
+xmlCursorRequired :: Zip.Archive -> FilePath -> Either ParseError Cursor
+xmlCursorRequired ar fname = maybe (Left $ MissingFile fname) Right =<< xmlCursor ar fname
 
 -- | Get shared string table
-getSharedStrings  :: Zip.Archive -> SharedStringTable
-getSharedStrings x = case xmlCursor x "xl/sharedStrings.xml" of
-    Nothing ->
-      error "invalid shared strings"
-    Just c ->
-      let [sst] = fromCursor c in sst
+getSharedStrings  :: Zip.Archive -> Either ParseError SharedStringTable
+getSharedStrings x = head . fromCursor <$> xmlCursorRequired x "xl/sharedStrings.xml"
 
 getStyles :: Zip.Archive -> Styles
 getStyles ar = case Zip.fromEntry <$> Zip.findEntryByPath "xl/styles.xml" ar of
   Nothing  -> Styles L.empty
   Just xml -> Styles xml
 
-getComments :: Zip.Archive -> FilePath -> Maybe CommentTable
-getComments ar fp = listToMaybe =<< fromCursor <$> xmlCursor ar fp
+getComments :: Zip.Archive -> FilePath -> Either ParseError (Maybe CommentTable)
+getComments ar fp = (listToMaybe . fromCursor =<<) <$> xmlCursor ar fp  --listToMaybe =<< fromCursor <$$> xmlCursor ar fp
 
-getCustomProperties :: Zip.Archive -> CustomProperties
-getCustomProperties ar = case fromCursor <$> xmlCursor ar "docProps/custom.xml" of
-    Just [cp] -> cp
-    _   -> CustomProperties.empty
+getCustomProperties :: Zip.Archive -> Either ParseError CustomProperties
+getCustomProperties ar = maybe CustomProperties.empty (head . fromCursor) <$> xmlCursor ar "docProps/custom.xml"
 
 -- | readWorkbook pulls the names of the sheets and the defined names
-readWorkbook :: Zip.Archive -> ([WorksheetFile], DefinedNames)
-readWorkbook ar = case xmlCursor ar wbPath of
-  Nothing ->
-    error "invalid workbook"
-  Just c ->
-    let
-        sheets = c $/ element (n"sheets") &/ element (n"sheet") >=>
+readWorkbook :: Zip.Archive -> Either ParseError ([WorksheetFile], DefinedNames)
+readWorkbook ar = do -- case xmlCursor ar wbPath of
+  let wbPath = "xl/workbook.xml"
+  cur <- xmlCursorRequired ar wbPath
+  wbRels <- getRels ar wbPath
+  let -- Specification says the 'name' is required.
+      mkDefinedName :: Cursor -> [(Text, Maybe Text, Text)]
+      mkDefinedName c = return ( head $ attribute "name" c
+                               , listToMaybe $ attribute "localSheetId" c
+                               , T.concat $ c $/ content
+                               )
+
+      sheets = cur $/ element (n"sheets") &/ element (n"sheet") >=>
                     liftA2 (worksheetFile wbRels) <$> attribute "name" <*> (attribute (odr"id") &| RefId)
-        wbRels = getRels ar wbPath
-        names = c $/ element (n"definedNames") &/ element (n"definedName") >=> mkDefinedName
-    in (sheets, DefinedNames names)
-  where
-    wbPath = "xl/workbook.xml"
-    -- Specification says the 'name' is required.
-    mkDefinedName :: Cursor -> [(Text, Maybe Text, Text)]
-    mkDefinedName c = return ( head $ attribute "name" c
-                             , listToMaybe $ attribute "localSheetId" c
-                             , T.concat $ c $/ content
-                             )
+      names = cur $/ element (n"definedNames") &/ element (n"definedName") >=> mkDefinedName
+  return $ (sheets, DefinedNames names)
+
 
 worksheetFile :: Relationships -> Text -> RefId -> WorksheetFile
 worksheetFile wbRels name rId = WorksheetFile name path
   where
     path = relTarget . fromJustNote "sheet path" $ Relationships.lookup rId wbRels
 
-getRels :: Zip.Archive -> FilePath -> Relationships
-getRels ar fp =
+getRels :: Zip.Archive -> FilePath -> Either ParseError Relationships
+getRels ar fp = do
     let (dir, file) = splitFileName fp
         relsPath = dir </> "_rels" </> file <.> "rels"
-    in case xmlCursor ar relsPath of
-        Nothing ->
-            Relationships.empty
-        Just c  ->
-            let [rels] = fromCursor c in setTargetsFrom fp rels
+    c <- xmlCursor ar relsPath
+    return $ maybe Relationships.empty (setTargetsFrom fp . head . fromCursor) c
 
 int :: Text -> Int
 int = either error fst . T.decimal

--- a/src/Codec/Xlsx/Parser.hs
+++ b/src/Codec/Xlsx/Parser.hs
@@ -84,9 +84,9 @@ extractSheet ar sst wf = do
       commentTarget :: Maybe FilePath
       commentTarget = relTarget <$> findRelByType commentsType sheetRels
 
-  commentsMap :: Maybe CommentTable <- maybe (Right Nothing) (getComments ar) commentTarget --  getComments ar <$> commentTarget
+  commentsMap :: Maybe CommentTable <- maybe (Right Nothing) (getComments ar) commentTarget
 
-        -- Likewise, @pageSetup@ also occurs either 0 or 1 times
+  -- Likewise, @pageSetup@ also occurs either 0 or 1 times
   let pageSetup = listToMaybe $ cur $/ element (n"pageSetup") >=> fromCursor
 
       cws = cur $/ element (n"cols") &/ element (n"col") >=> fromCursor
@@ -168,14 +168,14 @@ getStyles ar = case Zip.fromEntry <$> Zip.findEntryByPath "xl/styles.xml" ar of
   Just xml -> Styles xml
 
 getComments :: Zip.Archive -> FilePath -> Either ParseError (Maybe CommentTable)
-getComments ar fp = (listToMaybe . fromCursor =<<) <$> xmlCursor ar fp  --listToMaybe =<< fromCursor <$$> xmlCursor ar fp
+getComments ar fp = (listToMaybe . fromCursor =<<) <$> xmlCursor ar fp
 
 getCustomProperties :: Zip.Archive -> Either ParseError CustomProperties
 getCustomProperties ar = maybe CustomProperties.empty (head . fromCursor) <$> xmlCursor ar "docProps/custom.xml"
 
 -- | readWorkbook pulls the names of the sheets and the defined names
 readWorkbook :: Zip.Archive -> Either ParseError ([WorksheetFile], DefinedNames)
-readWorkbook ar = do -- case xmlCursor ar wbPath of
+readWorkbook ar = do
   let wbPath = "xl/workbook.xml"
   cur <- xmlCursorRequired ar wbPath
   wbRels <- getRels ar wbPath

--- a/src/Codec/Xlsx/Parser.hs
+++ b/src/Codec/Xlsx/Parser.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE NoMonomorphismRestriction #-}
 {-# LANGUAGE OverloadedStrings         #-}
@@ -5,15 +6,16 @@
 -- | This module provides a function for reading .xlsx files
 module Codec.Xlsx.Parser
     ( toXlsx
-    , toXlsxEither
+    , toXlsxOrError
     , ParseError (..)
     ) where
 
 import qualified Codec.Archive.Zip                           as Zip
 import           Control.Applicative
 import           Control.Arrow                               ((&&&))
+import           Control.Monad                               (liftM)
+import           Control.Monad.Except                        (MonadError(..))
 import           Control.Monad.IO.Class                      ()
-import           Data.Bifunctor                              (bimap, first)
 import qualified Data.ByteString.Lazy                        as L
 import           Data.ByteString.Lazy.Char8                  ()
 import           Data.List
@@ -39,10 +41,9 @@ import           Codec.Xlsx.Types.Internal.CustomProperties  as CustomProperties
 import           Codec.Xlsx.Types.Internal.Relationships     as Relationships
 import           Codec.Xlsx.Types.Internal.SharedStringTable
 
-
 -- | Reads `Xlsx' from raw data (lazy bytestring)
 toXlsx :: L.ByteString -> Xlsx
-toXlsx = either (error . show) id . toXlsxEither
+toXlsx = either (error . show) id . toXlsxOrError
 
 data ParseError = InvalidZipArchive
                 | MissingFile FilePath
@@ -50,12 +51,12 @@ data ParseError = InvalidZipArchive
                 deriving (Show, Eq)
 
 -- | Reads `Xlsx' from raw data (lazy bytestring), failing with Left on parse error
-toXlsxEither :: L.ByteString -> Either ParseError Xlsx
-toXlsxEither bs = do
-  ar <- first (const InvalidZipArchive) $ Zip.toArchiveOrFail bs
+toXlsxOrError :: MonadError ParseError m => L.ByteString -> m Xlsx
+toXlsxOrError bs = do
+  ar <- Zip.toArchiveOrFail bs `whenLeftThrow` const InvalidZipArchive
   sst <- getSharedStrings ar
   (wfs, names) <- readWorkbook ar
-  sheets <- sequenceA . M.fromList $ map (wfName &&& extractSheet ar sst) wfs
+  sheets <- sequence . M.fromList $ map (wfName &&& extractSheet ar sst) wfs
   CustomProperties customPropMap <- getCustomProperties ar
   return $ Xlsx sheets (getStyles ar) names customPropMap
 
@@ -64,14 +65,18 @@ data WorksheetFile = WorksheetFile { wfName :: Text
                                    }
                    deriving Show
 
-extractSheet :: Zip.Archive
+extractSheet :: MonadError ParseError m
+             => Zip.Archive
              -> SharedStringTable
              -> WorksheetFile
-             -> Either ParseError Worksheet
+             -> m Worksheet
 extractSheet ar sst wf = do
-  let  file = fromJust $ Zip.fromEntry <$> Zip.findEntryByPath (wfPath wf) ar
-  cur <- bimap (const $ MissingFile (wfPath wf)) fromDocument $ parseLBS def file
-  sheetRels <- getRels ar (wfPath wf)
+  let filePath = wfPath wf
+  file <- Zip.fromEntry `fmap` Zip.findEntryByPath filePath ar
+          `whenNothingThrow` MissingFile filePath
+  cur <- fromDocument `fmap` parseLBS def file
+         `whenLeftThrow` const (InvalidFile filePath)
+  sheetRels <- getRels ar filePath
 
   -- The specification says the file should contain either 0 or 1 @sheetViews@
   -- (4th edition, section 18.3.1.88, p. 1704 and definition CT_Worksheet, p. 3910)
@@ -84,7 +89,7 @@ extractSheet ar sst wf = do
       commentTarget :: Maybe FilePath
       commentTarget = relTarget <$> findRelByType commentsType sheetRels
 
-  commentsMap :: Maybe CommentTable <- maybe (Right Nothing) (getComments ar) commentTarget
+  commentsMap :: Maybe CommentTable <- maybe (return Nothing) (getComments ar) commentTarget
 
   -- Likewise, @pageSetup@ also occurs either 0 or 1 times
   let pageSetup = listToMaybe $ cur $/ element (n"pageSetup") >=> fromCursor
@@ -149,32 +154,30 @@ extractCellValue _ "b" "0" = [CellBool False]
 extractCellValue _ _ _ = []
 
 -- | Get xml cursor from the specified file inside the zip archive.
-xmlCursor :: Zip.Archive -> FilePath -> Either ParseError (Maybe Cursor)
-xmlCursor ar fname = maybe (Right Nothing) parse $ Zip.findEntryByPath fname ar
-  where
-    parse entry = bimap (const $ InvalidFile fname) (return . fromDocument) $ parseLBS def (Zip.fromEntry entry)
+xmlCursor :: MonadError ParseError m => Zip.Archive -> FilePath -> m (Maybe Cursor)
+xmlCursor ar fname = maybe (return Nothing) parse $ Zip.findEntryByPath fname ar
+  where parse entry = (return . fromDocument) `fmap` parseLBS def (Zip.fromEntry entry)
+                      `whenLeftThrow` const (InvalidFile fname)
 
 -- | Get xml cursor from the given file, failing with MissingFile if not found.
-xmlCursorRequired :: Zip.Archive -> FilePath -> Either ParseError Cursor
-xmlCursorRequired ar fname = maybe (Left $ MissingFile fname) Right =<< xmlCursor ar fname
+xmlCursorRequired :: MonadError ParseError m => Zip.Archive -> FilePath -> m Cursor
+xmlCursorRequired ar fname = xmlCursor ar fname >>= (`whenNothingThrow` MissingFile fname)
 
 -- | Get shared string table
-getSharedStrings  :: Zip.Archive -> Either ParseError SharedStringTable
-getSharedStrings x = head . fromCursor <$> xmlCursorRequired x "xl/sharedStrings.xml"
+getSharedStrings  :: MonadError ParseError m => Zip.Archive -> m SharedStringTable
+getSharedStrings x = (head . fromCursor) `liftM` xmlCursorRequired x "xl/sharedStrings.xml"
 
 getStyles :: Zip.Archive -> Styles
-getStyles ar = case Zip.fromEntry <$> Zip.findEntryByPath "xl/styles.xml" ar of
-  Nothing  -> Styles L.empty
-  Just xml -> Styles xml
+getStyles ar = Styles . fromMaybe L.empty $ Zip.fromEntry <$> Zip.findEntryByPath "xl/styles.xml" ar
 
-getComments :: Zip.Archive -> FilePath -> Either ParseError (Maybe CommentTable)
-getComments ar fp = (listToMaybe . fromCursor =<<) <$> xmlCursor ar fp
+getComments :: MonadError ParseError m => Zip.Archive -> FilePath -> m (Maybe CommentTable)
+getComments ar fp = (listToMaybe . fromCursor =<<) `liftM` xmlCursor ar fp
 
-getCustomProperties :: Zip.Archive -> Either ParseError CustomProperties
-getCustomProperties ar = maybe CustomProperties.empty (head . fromCursor) <$> xmlCursor ar "docProps/custom.xml"
+getCustomProperties :: MonadError ParseError m => Zip.Archive -> m CustomProperties
+getCustomProperties ar = maybe CustomProperties.empty (head . fromCursor) `liftM` xmlCursor ar "docProps/custom.xml"
 
 -- | readWorkbook pulls the names of the sheets and the defined names
-readWorkbook :: Zip.Archive -> Either ParseError ([WorksheetFile], DefinedNames)
+readWorkbook :: MonadError ParseError m => Zip.Archive -> m ([WorksheetFile], DefinedNames)
 readWorkbook ar = do
   let wbPath = "xl/workbook.xml"
   cur <- xmlCursorRequired ar wbPath
@@ -189,7 +192,7 @@ readWorkbook ar = do
       sheets = cur $/ element (n"sheets") &/ element (n"sheet") >=>
                     liftA2 (worksheetFile wbRels) <$> attribute "name" <*> (attribute (odr"id") &| RefId)
       names = cur $/ element (n"definedNames") &/ element (n"definedName") >=> mkDefinedName
-  return $ (sheets, DefinedNames names)
+  return (sheets, DefinedNames names)
 
 
 worksheetFile :: Relationships -> Text -> RefId -> WorksheetFile
@@ -197,7 +200,7 @@ worksheetFile wbRels name rId = WorksheetFile name path
   where
     path = relTarget . fromJustNote "sheet path" $ Relationships.lookup rId wbRels
 
-getRels :: Zip.Archive -> FilePath -> Either ParseError Relationships
+getRels :: MonadError ParseError m => Zip.Archive -> FilePath -> m Relationships
 getRels ar fp = do
     let (dir, file) = splitFileName fp
         relsPath = dir </> "_rels" </> file <.> "rels"
@@ -206,3 +209,14 @@ getRels ar fp = do
 
 int :: Text -> Int
 int = either error fst . T.decimal
+
+-- | Lift a 'Maybe' value into any 'MonadError'.
+-- Intended to be used infix; e.g.,
+--
+--    Just 3 `whenNothingThrow` SomeError
+whenNothingThrow :: MonadError e m => Maybe a -> e -> m a
+whenNothingThrow v e = maybe (throwError e) return v
+
+-- | Lift an 'Either' value into any 'MonadError'.
+whenLeftThrow :: MonadError e m => Either l r -> (l -> e) -> m r
+whenLeftThrow v e = either (throwError . e) return v

--- a/test/DataTest.hs
+++ b/test/DataTest.hs
@@ -58,6 +58,10 @@ main = defaultMain $
                                                  (formattedStyleSheet fmtd)
     , testCase "proper results from `conditionalltyFormatted`" $
         testCondFormattedResult @==? testRunCondFormatted
+    , testCase "toXlsxEither: properly formatted" $
+        Right testXlsx @==? toXlsxEither (fromXlsx testTime testXlsx)
+    , testCase "toXlsxEither: invalid format" $
+        Left InvalidZipArchive @==? toXlsxEither "this is not a valid XLSX file"
     ]
 
 testXlsx :: Xlsx

--- a/test/DataTest.hs
+++ b/test/DataTest.hs
@@ -59,9 +59,9 @@ main = defaultMain $
     , testCase "proper results from `conditionalltyFormatted`" $
         testCondFormattedResult @==? testRunCondFormatted
     , testCase "toXlsxEither: properly formatted" $
-        Right testXlsx @==? toXlsxOrError (fromXlsx testTime testXlsx)
+        Right testXlsx @==? toXlsxEither (fromXlsx testTime testXlsx)
     , testCase "toXlsxEither: invalid format" $
-        Left InvalidZipArchive @==? toXlsxOrError "this is not a valid XLSX file"
+        Left InvalidZipArchive @==? toXlsxEither "this is not a valid XLSX file"
     ]
 
 testXlsx :: Xlsx

--- a/test/DataTest.hs
+++ b/test/DataTest.hs
@@ -59,9 +59,9 @@ main = defaultMain $
     , testCase "proper results from `conditionalltyFormatted`" $
         testCondFormattedResult @==? testRunCondFormatted
     , testCase "toXlsxEither: properly formatted" $
-        Right testXlsx @==? toXlsxEither (fromXlsx testTime testXlsx)
+        Right testXlsx @==? toXlsxOrError (fromXlsx testTime testXlsx)
     , testCase "toXlsxEither: invalid format" $
-        Left InvalidZipArchive @==? toXlsxEither "this is not a valid XLSX file"
+        Left InvalidZipArchive @==? toXlsxOrError "this is not a valid XLSX file"
     ]
 
 testXlsx :: Xlsx

--- a/xlsx.cabal
+++ b/xlsx.cabal
@@ -67,7 +67,6 @@ Library
                    , filepath
                    , lens         >= 3.8 && < 5
                    , mtl          >= 2.1
-                   , mtl-compat
                    , network-uri
                    , old-locale   >= 1.0.0.5
                    , safe         >= 0.3

--- a/xlsx.cabal
+++ b/xlsx.cabal
@@ -57,16 +57,17 @@ Library
                    , Codec.Xlsx.Writer.Internal
 
   Build-depends:     base         == 4.*
-                   , bifunctors
                    , binary-search
                    , bytestring   >= 0.10.0.2
                    , conduit      >= 1.0.0
                    , containers   >= 0.5.0.0
                    , data-default
+                   , errors
                    , extra
                    , filepath
                    , lens         >= 3.8 && < 5
                    , mtl          >= 2.1
+                   , mtl-compat
                    , network-uri
                    , old-locale   >= 1.0.0.5
                    , safe         >= 0.3

--- a/xlsx.cabal
+++ b/xlsx.cabal
@@ -57,6 +57,7 @@ Library
                    , Codec.Xlsx.Writer.Internal
 
   Build-depends:     base         == 4.*
+                   , bifunctors
                    , binary-search
                    , bytestring   >= 0.10.0.2
                    , conduit      >= 1.0.0

--- a/xlsx.cabal
+++ b/xlsx.cabal
@@ -67,6 +67,7 @@ Library
                    , filepath
                    , lens         >= 3.8 && < 5
                    , mtl          >= 2.1
+                   , mtl-compat
                    , network-uri
                    , old-locale   >= 1.0.0.5
                    , safe         >= 0.3


### PR DESCRIPTION
An application I'm working on needed a bit better error reporting when XLSX files failed to parse. This change refactors `toXlsx` to depend on a `toXlsxEither` function that explicitly reports failure.

Test suite is green and it is working for some simple use cases in my application, but I haven't exercised it heavily. Let me know your thoughts on this approach. Thanks!

Brad