### PR TITLE
Add deriving Generic to all data types

### DIFF
--- a/src/Codec/Xlsx/Formatted.hs
+++ b/src/Codec/Xlsx/Formatted.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE RankNTypes      #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE DeriveGeneric #-}
 module Codec.Xlsx.Formatted (
     FormattedCell(..)
   , Formatted(..)

--- a/src/Codec/Xlsx/Formatted.hs
+++ b/src/Codec/Xlsx/Formatted.hs
@@ -118,7 +118,7 @@ data FormattedCondFmt = FormattedCondFmt
     , _condfmtDxf        :: Dxf
     , _condfmtPriority   :: Int
     , _condfmtStopIfTrue :: Maybe Bool
-    } deriving (Eq, Show)
+    } deriving (Eq, Show, Generic)
 
 makeLenses ''FormattedCondFmt
 
@@ -141,7 +141,7 @@ data Format = Format
     , _formatProtection   :: Maybe Protection
     , _formatPivotButton  :: Maybe Bool
     , _formatQuotePrefix  :: Maybe Bool
-    } deriving (Eq, Show)
+    } deriving (Eq, Show, Generic)
 
 makeLenses ''Format
 
@@ -153,7 +153,7 @@ data FormattedCell = FormattedCell
     , _formattedFormat  :: Format
     , _formattedColSpan :: Int
     , _formattedRowSpan :: Int
-    } deriving (Eq, Show)
+    } deriving (Eq, Show, Generic)
 
 makeLenses ''FormattedCell
 
@@ -200,7 +200,7 @@ data Formatted = Formatted {
 
     -- | The final list of cell merges; see '_wsMerges'
   , formattedMerges     :: [Range]
-  } deriving (Eq, Show)
+  } deriving (Eq, Show, Generic)
 
 -- | Higher level API for creating formatted documents
 --
@@ -289,7 +289,7 @@ data CondFormatted = CondFormatted {
     condformattedStyleSheet    :: StyleSheet
     -- | The final map of conditional formatting rules applied to ranges
     , condformattedFormattings :: Map SqRef ConditionalFormatting
-    } deriving (Eq, Show)
+    } deriving (Eq, Show, Generic)
 
 conditionallyFormatted :: Map CellRef [FormattedCondFmt] -> StyleSheet -> CondFormatted
 conditionallyFormatted cfs styleSheet = CondFormatted

--- a/src/Codec/Xlsx/Formatted.hs
+++ b/src/Codec/Xlsx/Formatted.hs
@@ -33,6 +33,8 @@ module Codec.Xlsx.Formatted (
   , condfmtStopIfTrue
   ) where
 
+import GHC.Generics (Generic)
+
 import           Control.Lens
 import           Control.Monad.State hiding (forM_, mapM)
 import           Data.Default

--- a/src/Codec/Xlsx/Lens.hs
+++ b/src/Codec/Xlsx/Lens.hs
@@ -19,6 +19,8 @@ module Codec.Xlsx.Lens
     , cellValueAtXY
  ) where
 
+import GHC.Generics (Generic)
+
 import           Codec.Xlsx.Types
 import           Control.Lens
 import           Data.Function       (on)

--- a/src/Codec/Xlsx/Lens.hs
+++ b/src/Codec/Xlsx/Lens.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP          #-}
 {-# LANGUAGE RankNTypes   #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE DeriveGeneric #-}
 
 -- | lenses to access sheets, cells and values of 'Xlsx'
 

--- a/src/Codec/Xlsx/Lens.hs
+++ b/src/Codec/Xlsx/Lens.hs
@@ -30,7 +30,7 @@ import           Control.Applicative
 #endif
 
 newtype SheetList = SheetList{ unSheetList :: [(Text, Worksheet)] }
-    deriving (Eq, Show)
+    deriving (Eq, Show, Generic)
 
 type instance IxValue (SheetList) = Worksheet
 type instance Index (SheetList) = Text

--- a/src/Codec/Xlsx/Parser.hs
+++ b/src/Codec/Xlsx/Parser.hs
@@ -13,6 +13,8 @@ module Codec.Xlsx.Parser
   , Parser
   ) where
 
+import GHC.Generics (Generic)
+
 import qualified Codec.Archive.Zip as Zip
 import Control.Applicative
 import Control.Arrow (left)

--- a/src/Codec/Xlsx/Parser.hs
+++ b/src/Codec/Xlsx/Parser.hs
@@ -57,7 +57,7 @@ data ParseError = InvalidZipArchive
                 | InvalidFile FilePath
                 | InvalidRef FilePath RefId
                 | InconsistentXlsx Text
-                deriving (Show, Eq)
+                deriving (Eq, Show, Generic)
 
 type Parser = Either ParseError
 
@@ -77,7 +77,7 @@ toXlsxEither bs = do
 data WorksheetFile = WorksheetFile { wfName :: Text
                                    , wfPath :: FilePath
                                    }
-                   deriving Show
+                   deriving (Show, Generic)
 
 type Caches = [(CacheId, (Text, CellRef, [CacheField]))]
 

--- a/src/Codec/Xlsx/Parser.hs
+++ b/src/Codec/Xlsx/Parser.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE RecordWildCards           #-}
 {-# LANGUAGE ScopedTypeVariables       #-}
 {-# LANGUAGE TupleSections             #-}
+{-# LANGUAGE DeriveGeneric #-}
 
 -- | This module provides a function for reading .xlsx files
 module Codec.Xlsx.Parser

--- a/src/Codec/Xlsx/Parser/Internal.hs
+++ b/src/Codec/Xlsx/Parser/Internal.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE DeriveGeneric #-}
 module Codec.Xlsx.Parser.Internal
     ( ParseException(..)
     , n_

--- a/src/Codec/Xlsx/Parser/Internal.hs
+++ b/src/Codec/Xlsx/Parser/Internal.hs
@@ -28,6 +28,8 @@ module Codec.Xlsx.Parser.Internal
     , rational
     ) where
 
+import GHC.Generics (Generic)
+
 import           Control.Exception       (Exception)
 import           Data.Maybe
 import           Data.Text               (Text)

--- a/src/Codec/Xlsx/Parser/Internal.hs
+++ b/src/Codec/Xlsx/Parser/Internal.hs
@@ -41,7 +41,7 @@ import           Control.Applicative
 #endif
 
 data ParseException = ParseException String
-                    deriving (Show, Typeable)
+                    deriving (Show, Typeable, Generic)
 
 instance Exception ParseException
 

--- a/src/Codec/Xlsx/Parser/Internal/PivotTable.hs
+++ b/src/Codec/Xlsx/Parser/Internal/PivotTable.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE DeriveGeneric #-}
 module Codec.Xlsx.Parser.Internal.PivotTable
   ( parsePivotTable
   , parseCache

--- a/src/Codec/Xlsx/Types.hs
+++ b/src/Codec/Xlsx/Types.hs
@@ -93,7 +93,7 @@ data RowProperties = RowProps
   , rowStyle  :: Maybe Int
   , rowHidden :: Bool
     -- ^ Whether row is visible or not
-  } deriving (Read,Eq,Show,Ord)
+  } deriving (Eq, Ord, Show, Read, Generic)
 
 instance Default RowProperties where
   def = RowProps { rowHeight = Nothing
@@ -127,7 +127,7 @@ data ColumnsProperties = ColumnsProperties
   , cpBestFit :: Bool
   -- ^ Flag indicating if the specified column(s) is set to 'best
   -- fit'.
-  } deriving (Eq, Show)
+  } deriving (Eq, Show, Generic)
 
 instance FromCursor ColumnsProperties where
   fromCursor c = do
@@ -155,7 +155,7 @@ data Worksheet = Worksheet
   , _wsAutoFilter :: Maybe AutoFilter
   , _wsTables :: [Table]
   , _wsProtection :: Maybe SheetProtection
-  } deriving (Eq, Show)
+  } deriving (Eq, Show, Generic)
 
 makeLenses ''Worksheet
 
@@ -178,7 +178,7 @@ instance Default Worksheet where
     }
 
 newtype Styles = Styles {unStyles :: L.ByteString}
-            deriving (Eq, Show)
+            deriving (Eq, Show, Generic)
 
 -- | Structured representation of Xlsx file (currently a subset of its contents)
 data Xlsx = Xlsx
@@ -186,7 +186,7 @@ data Xlsx = Xlsx
     , _xlStyles           :: Styles
     , _xlDefinedNames     :: DefinedNames
     , _xlCustomProperties :: Map Text Variant
-    } deriving (Eq, Show)
+    } deriving (Eq, Show, Generic)
 
 -- | Defined names
 --
@@ -210,7 +210,7 @@ data Xlsx = Xlsx
 --
 -- NOTE: Right now this is only a minimal implementation of defined names.
 newtype DefinedNames = DefinedNames [(Text, Maybe Text, Text)]
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic)
 
 makeLenses ''Xlsx
 

--- a/src/Codec/Xlsx/Types.hs
+++ b/src/Codec/Xlsx/Types.hs
@@ -53,6 +53,8 @@ module Codec.Xlsx.Types (
     , module X
     ) where
 
+import GHC.Generics (Generic)
+
 import           Control.Exception                      (SomeException,
                                                          toException)
 import           Control.Lens.TH

--- a/src/Codec/Xlsx/Types.hs
+++ b/src/Codec/Xlsx/Types.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE DeriveGeneric #-}
 module Codec.Xlsx.Types (
     -- * The main types
     Xlsx(..)

--- a/src/Codec/Xlsx/Types/AutoFilter.hs
+++ b/src/Codec/Xlsx/Types/AutoFilter.hs
@@ -4,6 +4,8 @@
 {-# LANGUAGE DeriveGeneric #-}
 module Codec.Xlsx.Types.AutoFilter where
 
+import GHC.Generics (Generic)
+
 import Control.Lens (makeLenses)
 import Data.Default
 import Data.Map (Map)

--- a/src/Codec/Xlsx/Types/AutoFilter.hs
+++ b/src/Codec/Xlsx/Types/AutoFilter.hs
@@ -30,12 +30,12 @@ data FilterColumn
                     CustomFilter
   | CustomFiltersAnd CustomFilter
                      CustomFilter
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic)
 
 data CustomFilter = CustomFilter
   { cfltOperator :: CustomFilterOperator
   , cfltValue :: Text
-  } deriving (Eq, Show)
+  } deriving (Eq, Show, Generic)
 
 data CustomFilterOperator
   = FltrEqual
@@ -50,7 +50,7 @@ data CustomFilterOperator
     -- ^ Show results which are less than or equal to criteria.
   | FltrNotEqual
     -- ^ Show results which are not equal to criteria.
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic)
 
 -- | AutoFilter temporarily hides rows based on a filter criteria,
 -- which is applied column by column to a table of datain the
@@ -62,7 +62,7 @@ data CustomFilterOperator
 data AutoFilter = AutoFilter
   { _afRef :: Maybe CellRef
   , _afFilterColumns :: Map Int FilterColumn
-  } deriving (Eq, Show)
+  } deriving (Eq, Show, Generic)
 
 makeLenses ''AutoFilter
 

--- a/src/Codec/Xlsx/Types/AutoFilter.hs
+++ b/src/Codec/Xlsx/Types/AutoFilter.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE DeriveGeneric #-}
 module Codec.Xlsx.Types.AutoFilter where
 
 import Control.Lens (makeLenses)

--- a/src/Codec/Xlsx/Types/Cell.hs
+++ b/src/Codec/Xlsx/Types/Cell.hs
@@ -41,7 +41,7 @@ data CellFormula
       -- the next time calculation is performed.
       -- [/Example/: This is always set on volatile functions,
       -- like =RAND(), and circular references. /end example/]
-      } deriving (Eq, Show)
+      } deriving (Eq, Show, Generic)
 
 simpleCellFormula :: Text -> CellFormula
 simpleCellFormula expr = NormalCellFormula
@@ -57,7 +57,7 @@ data Cell = Cell
     , _cellValue   :: Maybe CellValue
     , _cellComment :: Maybe Comment
     , _cellFormula :: Maybe CellFormula
-    } deriving (Eq, Show)
+    } deriving (Eq, Show, Generic)
 
 instance Default Cell where
     def = Cell Nothing Nothing Nothing Nothing

--- a/src/Codec/Xlsx/Types/Cell.hs
+++ b/src/Codec/Xlsx/Types/Cell.hs
@@ -13,6 +13,8 @@ module Codec.Xlsx.Types.Cell
   , CellMap
   ) where
 
+import GHC.Generics (Generic)
+
 import Control.Lens.TH (makeLenses)
 import Data.Default
 import Data.Map (Map)

--- a/src/Codec/Xlsx/Types/Cell.hs
+++ b/src/Codec/Xlsx/Types/Cell.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE DeriveGeneric #-}
 module Codec.Xlsx.Types.Cell
   ( CellFormula(..)
   , simpleCellFormula

--- a/src/Codec/Xlsx/Types/Comment.hs
+++ b/src/Codec/Xlsx/Types/Comment.hs
@@ -17,4 +17,4 @@ data Comment = Comment
     , _commentAuthor  :: Text
     -- ^ comment author
     , _commentVisible :: Bool
-    } deriving (Show, Eq)
+    } deriving (Eq, Show, Generic)

--- a/src/Codec/Xlsx/Types/Comment.hs
+++ b/src/Codec/Xlsx/Types/Comment.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE DeriveGeneric #-}
 module Codec.Xlsx.Types.Comment where
 
+import GHC.Generics (Generic)
+
 import           Data.Text               (Text)
 
 import           Codec.Xlsx.Types.Common

--- a/src/Codec/Xlsx/Types/Comment.hs
+++ b/src/Codec/Xlsx/Types/Comment.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Codec.Xlsx.Types.Comment where
 
 import           Data.Text               (Text)

--- a/src/Codec/Xlsx/Types/Common.hs
+++ b/src/Codec/Xlsx/Types/Common.hs
@@ -56,7 +56,7 @@ col2int = T.foldl' (\i c -> i * 26 + let2int c) 0
 -- See 18.18.62 @ST_Ref@ (p. 2482)
 newtype CellRef = CellRef
   { unCellRef :: Text
-  } deriving (Eq, Ord, Show)
+  } deriving (Eq, Ord, Show, Generic)
 
 -- | Render position in @(row, col)@ format to an Excel reference.
 --
@@ -107,7 +107,7 @@ fromRange r =
 --
 -- See 18.18.76 "ST_Sqref (Reference Sequence)" (p.2488)
 newtype SqRef = SqRef [CellRef]
-    deriving (Eq, Ord, Show)
+    deriving (Eq, Ord, Show, Generic)
 
 -- | Common type containing either simple string or rich formatted text.
 -- Used in @si@, @comment@ and @is@ elements
@@ -129,13 +129,13 @@ newtype SqRef = SqRef [CellRef]
 -- See @CT_Rst@, p. 3903
 data XlsxText = XlsxText Text
               | XlsxRichText [RichTextRun]
-              deriving (Show, Eq, Ord)
+              deriving (Eq, Ord, Show, Generic)
 
 -- | A formula
 --
 -- See 18.18.35 "ST_Formula (Formula)" (p. 2457)
 newtype Formula = Formula {unFormula :: Text}
-    deriving (Eq, Ord, Show)
+    deriving (Eq, Ord, Show, Generic)
 
 -- | Cell values include text, numbers and booleans,
 -- standard includes date format also but actually dates
@@ -146,7 +146,7 @@ data CellValue
   | CellDouble Double
   | CellBool Bool
   | CellRich [RichTextRun]
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
 
 {-------------------------------------------------------------------------------
   Parsing

--- a/src/Codec/Xlsx/Types/Common.hs
+++ b/src/Codec/Xlsx/Types/Common.hs
@@ -17,6 +17,8 @@ module Codec.Xlsx.Types.Common
   , col2int
   ) where
 
+import GHC.Generics (Generic)
+
 import Control.Arrow
 import Control.Monad (guard)
 import Data.Char

--- a/src/Codec/Xlsx/Types/Common.hs
+++ b/src/Codec/Xlsx/Types/Common.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveGeneric #-}
 module Codec.Xlsx.Types.Common
   ( CellRef(..)
   , singleCellRef

--- a/src/Codec/Xlsx/Types/ConditionalFormatting.hs
+++ b/src/Codec/Xlsx/Types/ConditionalFormatting.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
 {-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE DeriveGeneric #-}
 module Codec.Xlsx.Types.ConditionalFormatting
     ( ConditionalFormatting
     , CfRule(..)

--- a/src/Codec/Xlsx/Types/ConditionalFormatting.hs
+++ b/src/Codec/Xlsx/Types/ConditionalFormatting.hs
@@ -18,6 +18,8 @@ module Codec.Xlsx.Types.ConditionalFormatting
     , topCfPriority
     ) where
 
+import GHC.Generics (Generic)
+
 import           Control.Lens               (makeLenses)
 import           Data.Map                   (Map)
 import qualified Data.Map                   as M

--- a/src/Codec/Xlsx/Types/ConditionalFormatting.hs
+++ b/src/Codec/Xlsx/Types/ConditionalFormatting.hs
@@ -46,7 +46,7 @@ data OperatorExpression
     | OpNotBetween Formula Formula -- ^ 'Not between' operator
     | OpNotContains Formula        -- ^ 'Does not contain' operator
     | OpNotEqual Formula           -- ^ 'Not equal to' operator
-    deriving (Eq, Ord, Show)
+    deriving (Eq, Ord, Show, Generic)
 
 -- | Used in a "contains dates" conditional formatting rule.
 -- These are dynamic time periods, which change based on
@@ -64,7 +64,7 @@ data TimePeriod
     | PerToday      -- ^ Today's date.
     | PerTomorrow   -- ^ Tomorrow's date.
     | PerYesterday  -- ^ Yesterday's date.
-    deriving (Eq, Ord, Show)
+    deriving (Eq, Ord, Show, Generic)
 
 -- | Conditions which could be used for conditional formatting
 --
@@ -129,7 +129,7 @@ data Condition
     -- TODO: timePeriod
     -- TODO: top10
     -- TODO: uniqueValues
-    deriving (Eq, Ord, Show)
+    deriving (Eq, Ord, Show, Generic)
 
 -- | This collection represents a description of a conditional formatting rule.
 --
@@ -149,7 +149,7 @@ data CfRule = CfRule
     -- be applied over this rule, when this rule
     -- evaluates to true.
     , _cfrStopIfTrue :: Maybe Bool
-    } deriving (Eq, Ord, Show)
+    } deriving (Eq, Ord, Show, Generic)
 
 makeLenses ''CfRule
 

--- a/src/Codec/Xlsx/Types/DataValidation.hs
+++ b/src/Codec/Xlsx/Types/DataValidation.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
 {-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE DeriveGeneric #-}
 module Codec.Xlsx.Types.DataValidation where
 
 import           Control.Lens.TH            (makeLenses)

--- a/src/Codec/Xlsx/Types/DataValidation.hs
+++ b/src/Codec/Xlsx/Types/DataValidation.hs
@@ -4,6 +4,8 @@
 {-# LANGUAGE DeriveGeneric #-}
 module Codec.Xlsx.Types.DataValidation where
 
+import GHC.Generics (Generic)
+
 import           Control.Lens.TH            (makeLenses)
 import           Control.Monad              ((>=>))
 import           Data.Char                  (isSpace)

--- a/src/Codec/Xlsx/Types/DataValidation.hs
+++ b/src/Codec/Xlsx/Types/DataValidation.hs
@@ -29,7 +29,7 @@ data ValidationExpression
     | ValLessThanOrEqual Formula    -- ^ "Less than or equal to" operator
     | ValNotBetween Formula Formula -- ^ "Not between" operator
     | ValNotEqual Formula           -- ^ "Not equal to" operator
-    deriving (Eq, Show)
+    deriving (Eq, Show, Generic)
 
 -- See 18.18.21 "ST_DataValidationType (Data Validation Type)" (p. 2440/2450)
 data ValidationType
@@ -41,14 +41,14 @@ data ValidationType
     | ValidationTypeTextLength ValidationExpression
     | ValidationTypeTime       ValidationExpression
     | ValidationTypeWhole      ValidationExpression
-    deriving (Eq, Show)
+    deriving (Eq, Show, Generic)
 
 -- See 18.18.18 "ST_DataValidationErrorStyle (Data Validation Error Styles)" (p. 2438/2448)
 data ErrorStyle
     = ErrorStyleInformation
     | ErrorStyleStop
     | ErrorStyleWarning
-    deriving (Eq, Show)
+    deriving (Eq, Show, Generic)
 
 -- See 18.3.1.32 "dataValidation (Data Validation)" (p. 1614/1624)
 data DataValidation = DataValidation
@@ -62,7 +62,7 @@ data DataValidation = DataValidation
     , _dvShowErrorMessage :: Bool
     , _dvShowInputMessage :: Bool
     , _dvValidationType   :: ValidationType
-    } deriving (Eq, Show)
+    } deriving (Eq, Show, Generic)
 
 makeLenses ''DataValidation
 

--- a/src/Codec/Xlsx/Types/Drawing.hs
+++ b/src/Codec/Xlsx/Types/Drawing.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE DeriveGeneric #-}
 module Codec.Xlsx.Types.Drawing where
 
 import Control.Arrow (first)

--- a/src/Codec/Xlsx/Types/Drawing.hs
+++ b/src/Codec/Xlsx/Types/Drawing.hs
@@ -11,6 +11,8 @@
 {-# LANGUAGE DeriveGeneric #-}
 module Codec.Xlsx.Types.Drawing where
 
+import GHC.Generics (Generic)
+
 import Control.Arrow (first)
 import Control.Lens.TH
 import Data.ByteString.Lazy (ByteString)

--- a/src/Codec/Xlsx/Types/Drawing.hs
+++ b/src/Codec/Xlsx/Types/Drawing.hs
@@ -41,14 +41,14 @@ data FileInfo = FileInfo
     -- if interoperability is wanted
     , _fiContents    :: ByteString
     -- ^ image file contents
-    } deriving (Eq, Show)
+    } deriving (Eq, Show, Generic)
 
 data Marker = Marker
     { _mrkCol    :: Int
     , _mrkColOff :: Coordinate
     , _mrkRow    :: Int
     , _mrkRowOff :: Coordinate
-    } deriving (Eq, Show)
+    } deriving (Eq, Show, Generic)
 
 unqMarker :: (Int, Int) -> (Int, Int) -> Marker
 unqMarker (col, colOff) (row, rowOff) =
@@ -58,7 +58,7 @@ data EditAs
     = EditAsTwoCell
     | EditAsOneCell
     | EditAsAbsolute
-    deriving (Eq,Show)
+    deriving (Eq, Show, Generic)
 
 data Anchoring
     = AbsoluteAnchor
@@ -74,7 +74,7 @@ data Anchoring
       , tcaTo     :: Marker
       , tcaEditAs :: EditAs
       }
-    deriving (Eq, Show)
+    deriving (Eq, Show, Generic)
 
 data DrawingObject p g
   = Picture { _picMacro :: Maybe Text
@@ -88,7 +88,7 @@ data DrawingObject p g
            ,  _grChartSpace :: g
            ,  _grTransform :: Transform2D}
     -- TODO: sp, grpSp, graphicFrame, cxnSp, contentPart
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic)
 
 -- | basic function to create picture drawing object
 --
@@ -147,21 +147,21 @@ data ClientData = ClientData
     , _cldPrintsWithSheet :: Bool
     -- ^ This attribute indicates whether to print drawing elements
     -- when printing the sheet.
-    } deriving (Eq, Show)
+    } deriving (Eq, Show, Generic)
 
 data PicNonVisual = PicNonVisual
   { _pnvDrawingProps :: NonVisualDrawingProperties
     -- TODO: cNvPicPr
-  } deriving (Eq, Show)
+  } deriving (Eq, Show, Generic)
 
 data GraphNonVisual = GraphNonVisual
   { _gnvDrawingProps :: NonVisualDrawingProperties
     -- TODO cNvGraphicFramePr
-  } deriving (Eq, Show)
+  } deriving (Eq, Show, Generic)
 
 newtype DrawingElementId = DrawingElementId
   { unDrawingElementId :: Int
-  } deriving (Eq, Show)
+  } deriving (Eq, Show, Generic)
 
 -- see 20.1.2.2.8 "cNvPr (Non-Visual Drawing Properties)" (p. 2731)
 data NonVisualDrawingProperties = NonVisualDrawingProperties
@@ -178,13 +178,13 @@ data NonVisualDrawingProperties = NonVisualDrawingProperties
     -- ^ Alternative Text for Object
     , _nvdpHidden      :: Bool
     , _nvdpTitle       :: Maybe Text
-    } deriving (Eq, Show)
+    } deriving (Eq, Show, Generic)
 
 data BlipFillProperties a = BlipFillProperties
     { _bfpImageInfo :: Maybe a
     , _bfpFillMode  :: Maybe FillMode
     -- TODO: dpi, rotWithShape, srcRect
-    } deriving (Eq, Show)
+    } deriving (Eq, Show, Generic)
 
 -- see @a_EG_FillModeProperties@ (p. 4319)
 data FillMode
@@ -192,14 +192,14 @@ data FillMode
     = FillTile    -- TODO: tx, ty, sx, sy, flip, algn
     -- See 20.1.8.56 "stretch (Stretch)" (p. 2879)
     | FillStretch -- TODO: srcRect
-    deriving (Eq, Show)
+    deriving (Eq, Show, Generic)
 
 -- See @EG_Anchor@ (p. 4052)
 data Anchor p g = Anchor
     { _anchAnchoring  :: Anchoring
     , _anchObject     :: DrawingObject p g
     , _anchClientData :: ClientData
-    } deriving (Eq, Show)
+    } deriving (Eq, Show, Generic)
 
 -- | simple drawing object anchoring using one cell as a top lelft
 -- corner and dimensions of that object
@@ -219,7 +219,7 @@ simpleAnchorXY (x, y) sz obj =
 
 data GenericDrawing p g = Drawing
     { _xdrAnchors :: [Anchor p g]
-    } deriving (Eq, Show)
+    } deriving (Eq, Show, Generic)
 
 -- See 20.5.2.35 "wsDr (Worksheet Drawing)" (p. 3176)
 type Drawing = GenericDrawing FileInfo ChartSpace

--- a/src/Codec/Xlsx/Types/Drawing/Chart.hs
+++ b/src/Codec/Xlsx/Types/Drawing/Chart.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE DeriveGeneric #-}
 module Codec.Xlsx.Types.Drawing.Chart where
 
 import Control.Lens.TH

--- a/src/Codec/Xlsx/Types/Drawing/Chart.hs
+++ b/src/Codec/Xlsx/Types/Drawing/Chart.hs
@@ -5,6 +5,8 @@
 {-# LANGUAGE DeriveGeneric #-}
 module Codec.Xlsx.Types.Drawing.Chart where
 
+import GHC.Generics (Generic)
+
 import Control.Lens.TH
 import Data.Default
 import Data.Maybe (catMaybes, maybeToList)

--- a/src/Codec/Xlsx/Types/Drawing/Chart.hs
+++ b/src/Codec/Xlsx/Types/Drawing/Chart.hs
@@ -29,14 +29,14 @@ data ChartSpace = ChartSpace
   , _chspLegend :: Maybe Legend
   , _chspPlotVisOnly :: Maybe Bool
   , _chspDispBlanksAs :: Maybe DispBlanksAs
-  } deriving (Eq, Show)
+  } deriving (Eq, Show, Generic)
 
 -- | Chart title
 --
 -- TODO: layout, overlay, spPr, txPr, extLst
 newtype ChartTitle =
   ChartTitle TextBody
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic)
 
 -- | This simple type specifies the possible ways to display blanks.
 --
@@ -48,13 +48,13 @@ data DispBlanksAs
     -- ^ Specifies that blank values shall be spanned with a line.
   | DispBlanksAsZero
     -- ^ Specifies that blank values shall be treated as zero.
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic)
 
 -- TODO: legendEntry, layout, overlay, spPr, txPr, extLst
 data Legend = Legend
     { _legendPos     :: Maybe LegendPos
     , _legendOverlay :: Maybe Bool
-    } deriving (Eq, Show)
+    } deriving (Eq, Show, Generic)
 
 -- See 21.2.3.24 "ST_LegendPos (Legend Position)" (p. 3449)
 data LegendPos
@@ -73,7 +73,7 @@ data LegendPos
   | LegendTopRight
     -- ^ tr (Top Right) Specifies that the legend shall be drawn at
     -- the top right of the chart.
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic)
 
 -- | Specific Chart
 -- TODO:
@@ -101,7 +101,7 @@ data Chart
   | ScatterChart { _scchStyle :: ScatterStyle
                  , _scchSeries :: [ScatterSeries]
                  }
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic)
 
 -- | Possible groupings for a bar chart
 --
@@ -116,7 +116,7 @@ data ChartGrouping
   | StandardGrouping
     -- ^(Standard) Specifies that the chart series are drawn on the value
     -- axis.
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic)
 
 -- | Possible directions for a bar chart
 --
@@ -124,7 +124,7 @@ data ChartGrouping
 data BarDirection
   = DirectionBar
   | DirectionColumn
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic)
 
 -- | Possible styles of scatter chart
 --
@@ -140,7 +140,7 @@ data ScatterStyle
   | ScatterMarker
   | ScatterSmooth
   | ScatterSmoothMarker
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic)
 
 -- | Single data point options
 --
@@ -150,7 +150,7 @@ data ScatterStyle
 data DataPoint = DataPoint
   { _dpMarker :: Maybe DataMarker
   , _dpShapeProperties :: Maybe ShapeProperties
-  } deriving (Eq, Show)
+  } deriving (Eq, Show, Generic)
 
 -- | Specifies common series options
 -- TODO: spPr
@@ -161,7 +161,7 @@ data Series = Series
     -- ^ specifies text for a series name, without rich text formatting
     -- currently only reference formula is supported
   , _serShapeProperties :: Maybe ShapeProperties
-  } deriving (Eq, Show)
+  } deriving (Eq, Show, Generic)
 
 -- | A series on a line chart
 --
@@ -175,7 +175,7 @@ data LineSeries = LineSeries
   , _lnserVal :: Maybe Formula
     -- ^ currently only reference formula is supported
   , _lnserSmooth :: Maybe Bool
-  } deriving (Eq, Show)
+  } deriving (Eq, Show, Generic)
 
 -- | A series on an area chart
 --
@@ -186,7 +186,7 @@ data AreaSeries = AreaSeries
   { _arserShared :: Series
   , _arserDataLblProps :: Maybe DataLblProps
   , _arserVal :: Maybe Formula
-  } deriving (Eq, Show)
+  } deriving (Eq, Show, Generic)
 
 -- | A series on a bar chart
 --
@@ -198,7 +198,7 @@ data BarSeries = BarSeries
   { _brserShared :: Series
   , _brserDataLblProps :: Maybe DataLblProps
   , _brserVal :: Maybe Formula
-  } deriving (Eq, Show)
+  } deriving (Eq, Show, Generic)
 
 -- | A series on a pie chart
 --
@@ -212,7 +212,7 @@ data PieSeries = PieSeries
   -- properly colored
   , _piserDataLblProps :: Maybe DataLblProps
   , _piserVal :: Maybe Formula
-  } deriving (Eq, Show)
+  } deriving (Eq, Show, Generic)
 
 -- | A series on a scatter chart
 --
@@ -226,14 +226,14 @@ data ScatterSeries = ScatterSeries
   , _scserXVal :: Maybe Formula
   , _scserYVal :: Maybe Formula
   , _scserSmooth :: Maybe Bool
-  } deriving (Eq, Show)
+  } deriving (Eq, Show, Generic)
 
 -- See @CT_Marker@ (p. 4061)
 data DataMarker = DataMarker
   { _dmrkSymbol :: Maybe DataMarkerSymbol
   , _dmrkSize :: Maybe Int
     -- ^ integer between 2 and 72, specifying a size in points
-  } deriving (Eq, Show)
+  } deriving (Eq, Show, Generic)
 
 data DataMarkerSymbol
   = DataMarkerCircle
@@ -248,7 +248,7 @@ data DataMarkerSymbol
   | DataMarkerTriangle
   | DataMarkerX
   | DataMarkerAuto
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic)
 
 -- | Settings for the data labels for an entire series or the
 -- entire chart
@@ -262,7 +262,7 @@ data DataLblProps = DataLblProps
   , _dlblShowCatName :: Maybe Bool
   , _dlblShowSerName :: Maybe Bool
   , _dlblShowPercent :: Maybe Bool
-  } deriving (Eq, Show)
+  } deriving (Eq, Show, Generic)
 
 -- | Specifies the possible positions for tick marks.
 
@@ -276,7 +276,7 @@ data TickMark
     -- ^ (None) Specifies there shall be no tick marks.
   | TickMarkOut
     -- ^ (Outside) Specifies the tick marks shall be outside the plot area.
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic)
 
 makeLenses ''DataPoint
 

--- a/src/Codec/Xlsx/Types/Drawing/Common.hs
+++ b/src/Codec/Xlsx/Types/Drawing/Common.hs
@@ -28,7 +28,7 @@ import Codec.Xlsx.Writer.Internal
 -- angles are counter-clockwise (i.e., towards the negative y axis).
 newtype Angle =
   Angle Int
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic)
 
 -- | A string with rich text formatting
 --
@@ -58,7 +58,7 @@ data TextBody = TextBody
     -- aligns the text within the "bounds box" for the text.
   , _txbdParagraphs :: [TextParagraph]
     -- ^ Paragraphs of text within the containing text body
-  } deriving (Eq, Show)
+  } deriving (Eq, Show, Generic)
 
 -- | Text vertical overflow
 -- See 20.1.10.83 "ST_TextVertOverflowType (Text Vertical Overflow)" (p. 3083)
@@ -71,7 +71,7 @@ data TextVertOverflow
     -- there is text which is not visible.
   | TextVertOverflow
     -- ^ Overflow the text and pay no attention to top and bottom barriers.
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic)
 
 -- | If there is vertical text, determines what kind of vertical text is going to be used.
 --
@@ -100,7 +100,7 @@ data TextVertical
   | TextVerticalWordArtRtl
     -- ^  Specifies that vertical WordArt should be shown from right to left rather than
     -- left to right.
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic)
 
 -- | Text wrapping types
 --
@@ -111,7 +111,7 @@ data TextWrap
     -- paying attention to the bounding rectangle boundaries.
     | TextWrapSquare
     -- ^ Determines whether we wrap words within the bounding rectangle.
-    deriving (Eq, Show)
+    deriving (Eq, Show, Generic)
 
 -- | This type specifies a list of available anchoring types for text.
 --
@@ -137,13 +137,13 @@ data TextAnchoring
     -- text in a line, it does not justify.
   | TextAnchoringTop
     -- ^ Anchor the text at the top of the bounding rectangle.
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic)
 
 -- See 21.1.2.2.6 "p (Text Paragraphs)" (p. 3211)
 data TextParagraph = TextParagraph
   { _txpaDefCharProps :: Maybe TextCharacterProperties
   , _txpaRuns :: [TextRun]
-  } deriving (Eq, Show)
+  } deriving (Eq, Show, Generic)
 
 -- | Text character properties
 --
@@ -158,7 +158,7 @@ data TextCharacterProperties = TextCharacterProperties
   { _txchBold :: Bool
   , _txchItalic :: Bool
   , _txchUnderline :: Bool
-  } deriving (Eq, Show)
+  } deriving (Eq, Show, Generic)
 
 -- | Text run
 --
@@ -166,7 +166,7 @@ data TextCharacterProperties = TextCharacterProperties
 data TextRun = RegularRun
   { _txrCharProps :: Maybe TextCharacterProperties
   , _txrText :: Text
-  } deriving (Eq, Show)
+  } deriving (Eq, Show, Generic)
 
 -- | This simple type represents a one dimensional position or length
 --
@@ -177,7 +177,7 @@ data Coordinate
   | UniversalMeasure UnitIdentifier
                      Double
     -- ^ see 22.9.2.15 "ST_UniversalMeasure (Universal Measurement)" (p. 3793)
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic)
 
 -- | Units used in "Universal measure" coordinates
 -- see 22.9.2.15 "ST_UniversalMeasure (Universal Measurement)" (p. 3793)
@@ -188,13 +188,13 @@ data UnitIdentifier
   | UnitPt -- "pt" 1 pt = 1/72 in (informative)
   | UnitPc -- "pc" 1 pc = 12 pt (informative)
   | UnitPi -- "pi" 1 pi = 12 pt (informative)
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic)
 
 -- See @CT_Point2D@ (p. 3989)
 data Point2D = Point2D
   { _pt2dX :: Coordinate
   , _pt2dY :: Coordinate
-  } deriving (Eq, Show)
+  } deriving (Eq, Show, Generic)
 
 unqPoint2D :: Int -> Int -> Point2D
 unqPoint2D x y = Point2D (UnqCoordinate x) (UnqCoordinate y)
@@ -203,12 +203,12 @@ unqPoint2D x y = Point2D (UnqCoordinate x) (UnqCoordinate y)
 -- see 20.1.10.41 "ST_PositiveCoordinate (Positive Coordinate)" (p. 2942)
 newtype PositiveCoordinate =
   PositiveCoordinate Integer
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
 
 data PositiveSize2D = PositiveSize2D
   { _ps2dX :: PositiveCoordinate
   , _ps2dY :: PositiveCoordinate
-  } deriving (Eq, Show)
+  } deriving (Eq, Show, Generic)
 
 positiveSize2D :: Integer -> Integer -> PositiveSize2D
 positiveSize2D x y =
@@ -235,14 +235,14 @@ data Transform2D = Transform2D
   , _trExtents :: Maybe PositiveSize2D
     -- ^ See 20.1.7.3 "ext (Extents)" (p. 2846) or
     -- 20.5.2.14 "ext (Shape Extent)" (p. 3165)
-  } deriving (Eq, Show)
+  } deriving (Eq, Show, Generic)
 
 -- TODO: custGeom
 data Geometry =
   PresetGeometry
   -- TODO: prst, avList
   -- currently uses "rect" with empty avList
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic)
 
 -- See 20.1.2.2.35 "spPr (Shape Properties)" (p. 2751)
 data ShapeProperties = ShapeProperties
@@ -251,7 +251,7 @@ data ShapeProperties = ShapeProperties
   , _spFill :: Maybe FillProperties
   , _spOutline :: Maybe LineProperties
     -- TODO: bwMode, a_EG_EffectProperties, scene3d, sp3d, extLst
-  } deriving (Eq, Show)
+  } deriving (Eq, Show, Generic)
 
 -- | Specifies an outline style that can be applied to a number of
 -- different objects such as shapes and text.
@@ -266,7 +266,7 @@ data LineProperties = LineProperties
   -- ^ Specifies the width to be used for the underline stroke.  The
   -- value is in EMU, is greater of equal to 0 and maximum value is
   -- 20116800.
-  } deriving (Eq, Show)
+  } deriving (Eq, Show, Generic)
 
 -- | Color choice for some drawing element
 --
@@ -280,7 +280,7 @@ data ColorChoice =
   -- digits, RRGGBB. A perceptual gamma of 2.2 is used.
   --
   -- See 20.1.2.3.32 "srgbClr (RGB Color Model - Hex Variant)" (p. 2773)
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic)
 
 -- TODO: gradFill, pattFill
 data FillProperties =
@@ -289,7 +289,7 @@ data FillProperties =
   | SolidFill (Maybe ColorChoice)
   -- ^ Solid fill
   -- See 20.1.8.54 "solidFill (Solid Fill)" (p. 2879)
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic)
 
 -- | solid fill with color specified by hexadecimal RGB color
 solidRgb :: Text -> FillProperties

--- a/src/Codec/Xlsx/Types/Drawing/Common.hs
+++ b/src/Codec/Xlsx/Types/Drawing/Common.hs
@@ -5,6 +5,8 @@
 {-# LANGUAGE DeriveGeneric #-}
 module Codec.Xlsx.Types.Drawing.Common where
 
+import GHC.Generics (Generic)
+
 import Control.Arrow (first)
 import Control.Lens.TH
 import Control.Monad (join)

--- a/src/Codec/Xlsx/Types/Drawing/Common.hs
+++ b/src/Codec/Xlsx/Types/Drawing/Common.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE DeriveGeneric #-}
 module Codec.Xlsx.Types.Drawing.Common where
 
 import Control.Arrow (first)

--- a/src/Codec/Xlsx/Types/Internal.hs
+++ b/src/Codec/Xlsx/Types/Internal.hs
@@ -2,6 +2,8 @@
 {-# LANGUAGE DeriveGeneric #-}
 module Codec.Xlsx.Types.Internal where
 
+import GHC.Generics (Generic)
+
 import           Control.Arrow
 import           Data.Text                  (Text)
 

--- a/src/Codec/Xlsx/Types/Internal.hs
+++ b/src/Codec/Xlsx/Types/Internal.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveGeneric #-}
 module Codec.Xlsx.Types.Internal where
 
 import           Control.Arrow

--- a/src/Codec/Xlsx/Types/Internal.hs
+++ b/src/Codec/Xlsx/Types/Internal.hs
@@ -11,7 +11,7 @@ import           Control.Applicative
 import           Codec.Xlsx.Parser.Internal
 import           Codec.Xlsx.Writer.Internal
 
-newtype RefId = RefId { unRefId :: Text } deriving (Show, Eq, Ord)
+newtype RefId = RefId { unRefId :: Text } deriving (Eq, Ord, Show, Generic)
 
 instance ToAttrVal RefId where
     toAttrVal = toAttrVal . unRefId

--- a/src/Codec/Xlsx/Types/Internal/CfPair.hs
+++ b/src/Codec/Xlsx/Types/Internal/CfPair.hs
@@ -16,7 +16,7 @@ import           Codec.Xlsx.Writer.Internal
 -- See 18.3.1.18 "conditionalFormatting (Conditional Formatting)" (p. 1610)
 newtype CfPair = CfPair
     { unCfPair :: (SqRef, ConditionalFormatting)
-    } deriving (Eq, Show)
+    } deriving (Eq, Show, Generic)
 
 instance FromCursor CfPair where
     fromCursor cur = do

--- a/src/Codec/Xlsx/Types/Internal/CfPair.hs
+++ b/src/Codec/Xlsx/Types/Internal/CfPair.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveGeneric #-}
 module Codec.Xlsx.Types.Internal.CfPair where
 
 import           Text.XML.Cursor

--- a/src/Codec/Xlsx/Types/Internal/CfPair.hs
+++ b/src/Codec/Xlsx/Types/Internal/CfPair.hs
@@ -2,6 +2,8 @@
 {-# LANGUAGE DeriveGeneric #-}
 module Codec.Xlsx.Types.Internal.CfPair where
 
+import GHC.Generics (Generic)
+
 import           Text.XML.Cursor
 
 import           Codec.Xlsx.Parser.Internal

--- a/src/Codec/Xlsx/Types/Internal/CommentTable.hs
+++ b/src/Codec/Xlsx/Types/Internal/CommentTable.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE DeriveGeneric #-}
 module Codec.Xlsx.Types.Internal.CommentTable where
 
 import Data.ByteString.Lazy (ByteString)

--- a/src/Codec/Xlsx/Types/Internal/CommentTable.hs
+++ b/src/Codec/Xlsx/Types/Internal/CommentTable.hs
@@ -3,6 +3,8 @@
 {-# LANGUAGE DeriveGeneric #-}
 module Codec.Xlsx.Types.Internal.CommentTable where
 
+import GHC.Generics (Generic)
+
 import Data.ByteString.Lazy (ByteString)
 import qualified Data.ByteString.Lazy as LB
 import qualified Data.ByteString.Lazy.Char8 as LBC8

--- a/src/Codec/Xlsx/Types/Internal/CommentTable.hs
+++ b/src/Codec/Xlsx/Types/Internal/CommentTable.hs
@@ -23,7 +23,7 @@ import Codec.Xlsx.Writer.Internal
 
 newtype CommentTable = CommentTable
     { _commentsTable :: Map CellRef Comment }
-    deriving (Show, Eq)
+    deriving (Eq, Show, Generic)
 
 fromList :: [(CellRef, Comment)] -> CommentTable
 fromList = CommentTable . M.fromList

--- a/src/Codec/Xlsx/Types/Internal/ContentTypes.hs
+++ b/src/Codec/Xlsx/Types/Internal/ContentTypes.hs
@@ -4,6 +4,8 @@
 {-# LANGUAGE DeriveGeneric #-}
 module Codec.Xlsx.Types.Internal.ContentTypes where
 
+import GHC.Generics (Generic)
+
 import           Control.Arrow
 import           Data.Foldable              (asum)
 import           Data.Map                   (Map)

--- a/src/Codec/Xlsx/Types/Internal/ContentTypes.hs
+++ b/src/Codec/Xlsx/Types/Internal/ContentTypes.hs
@@ -22,17 +22,17 @@ import           Codec.Xlsx.Parser.Internal
 data CtDefault = CtDefault
     { dfltExtension   :: FilePath
     , dfltContentType :: Text
-    } deriving (Eq, Show)
+    } deriving (Eq, Show, Generic)
 
 data Override = Override
     { ovrPartName    :: FilePath
     , ovrContentType :: Text
-    } deriving (Eq, Show)
+    } deriving (Eq, Show, Generic)
 
 data ContentTypes = ContentTypes
     { ctDefaults :: Map FilePath Text
     , ctTypes    :: Map FilePath Text
-    } deriving (Eq, Show)
+    } deriving (Eq, Show, Generic)
 
 lookup :: FilePath -> ContentTypes -> Maybe Text
 lookup path ContentTypes{..} =

--- a/src/Codec/Xlsx/Types/Internal/ContentTypes.hs
+++ b/src/Codec/Xlsx/Types/Internal/ContentTypes.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP               #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE DeriveGeneric #-}
 module Codec.Xlsx.Types.Internal.ContentTypes where
 
 import           Control.Arrow

--- a/src/Codec/Xlsx/Types/Internal/CustomProperties.hs
+++ b/src/Codec/Xlsx/Types/Internal/CustomProperties.hs
@@ -2,6 +2,8 @@
 {-# LANGUAGE DeriveGeneric #-}
 module Codec.Xlsx.Types.Internal.CustomProperties where
 
+import GHC.Generics (Generic)
+
 import           Data.Map                   (Map)
 import qualified Data.Map                   as M
 import           Data.Text                  (Text)

--- a/src/Codec/Xlsx/Types/Internal/CustomProperties.hs
+++ b/src/Codec/Xlsx/Types/Internal/CustomProperties.hs
@@ -12,7 +12,7 @@ import           Codec.Xlsx.Types.Variant
 import           Codec.Xlsx.Writer.Internal
 
 newtype CustomProperties = CustomProperties (Map Text Variant)
-    deriving (Show, Eq)
+    deriving (Eq, Show, Generic)
 
 fromList :: [(Text, Variant)] -> CustomProperties
 fromList = CustomProperties . M.fromList

--- a/src/Codec/Xlsx/Types/Internal/CustomProperties.hs
+++ b/src/Codec/Xlsx/Types/Internal/CustomProperties.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveGeneric #-}
 module Codec.Xlsx.Types.Internal.CustomProperties where
 
 import           Data.Map                   (Map)

--- a/src/Codec/Xlsx/Types/Internal/DvPair.hs
+++ b/src/Codec/Xlsx/Types/Internal/DvPair.hs
@@ -15,7 +15,7 @@ import           Codec.Xlsx.Writer.Internal
 -- See 18.3.1.32 "dataValidation (Data Validation)" (p. 1614/1624)
 newtype DvPair = DvPair
     { unDvPair :: (SqRef, DataValidation)
-    } deriving (Eq, Show)
+    } deriving (Eq, Show, Generic)
 
 instance FromCursor DvPair where
     fromCursor cur = do

--- a/src/Codec/Xlsx/Types/Internal/DvPair.hs
+++ b/src/Codec/Xlsx/Types/Internal/DvPair.hs
@@ -2,6 +2,8 @@
 {-# LANGUAGE DeriveGeneric #-}
 module Codec.Xlsx.Types.Internal.DvPair where
 
+import GHC.Generics (Generic)
+
 import qualified Data.Map                   as M
 import           Text.XML                   (Element (..))
 

--- a/src/Codec/Xlsx/Types/Internal/DvPair.hs
+++ b/src/Codec/Xlsx/Types/Internal/DvPair.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveGeneric #-}
 module Codec.Xlsx.Types.Internal.DvPair where
 
 import qualified Data.Map                   as M

--- a/src/Codec/Xlsx/Types/Internal/NumFmtPair.hs
+++ b/src/Codec/Xlsx/Types/Internal/NumFmtPair.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveGeneric #-}
 module Codec.Xlsx.Types.Internal.NumFmtPair where
 
 import           Data.Text                  (Text)

--- a/src/Codec/Xlsx/Types/Internal/NumFmtPair.hs
+++ b/src/Codec/Xlsx/Types/Internal/NumFmtPair.hs
@@ -2,6 +2,8 @@
 {-# LANGUAGE DeriveGeneric #-}
 module Codec.Xlsx.Types.Internal.NumFmtPair where
 
+import GHC.Generics (Generic)
+
 import           Data.Text                  (Text)
 
 import           Codec.Xlsx.Parser.Internal

--- a/src/Codec/Xlsx/Types/Internal/NumFmtPair.hs
+++ b/src/Codec/Xlsx/Types/Internal/NumFmtPair.hs
@@ -11,7 +11,7 @@ import           Codec.Xlsx.Writer.Internal
 -- See 18.8.30 "numFmt (Number Format)" (p. 1777)
 newtype NumFmtPair = NumFmtPair
     { unNumFmtPair :: (Int, Text)
-    } deriving (Eq, Show)
+    } deriving (Eq, Show, Generic)
 
 instance FromCursor NumFmtPair where
     fromCursor cur = do

--- a/src/Codec/Xlsx/Types/Internal/Relationships.hs
+++ b/src/Codec/Xlsx/Types/Internal/Relationships.hs
@@ -4,6 +4,8 @@
 {-# LANGUAGE DeriveGeneric #-}
 module Codec.Xlsx.Types.Internal.Relationships where
 
+import GHC.Generics (Generic)
+
 import           Data.List                  (find)
 import           Data.Map                   (Map)
 import qualified Data.Map                   as Map

--- a/src/Codec/Xlsx/Types/Internal/Relationships.hs
+++ b/src/Codec/Xlsx/Types/Internal/Relationships.hs
@@ -26,7 +26,7 @@ import           Codec.Xlsx.Writer.Internal
 data Relationship = Relationship
     { relType   :: Text
     , relTarget :: FilePath
-    } deriving (Show, Eq)
+    } deriving (Eq, Show, Generic)
 
 -- | Describes relationships according to Open Packaging Convention
 --
@@ -34,7 +34,7 @@ data Relationship = Relationship
 -- Conventions
 newtype Relationships = Relationships
     { relMap :: Map RefId Relationship
-    } deriving (Show, Eq)
+    } deriving (Eq, Show, Generic)
 
 fromList :: [(RefId, Relationship)] -> Relationships
 fromList = Relationships . Map.fromList

--- a/src/Codec/Xlsx/Types/Internal/Relationships.hs
+++ b/src/Codec/Xlsx/Types/Internal/Relationships.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP               #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE DeriveGeneric #-}
 module Codec.Xlsx.Types.Internal.Relationships where
 
 import           Data.List                  (find)

--- a/src/Codec/Xlsx/Types/Internal/SharedStringTable.hs
+++ b/src/Codec/Xlsx/Types/Internal/SharedStringTable.hs
@@ -11,6 +11,8 @@ module Codec.Xlsx.Types.Internal.SharedStringTable (
   , sstEmpty
   ) where
 
+import GHC.Generics (Generic)
+
 import           Control.Monad
 
 import qualified Data.Map                   as Map

--- a/src/Codec/Xlsx/Types/Internal/SharedStringTable.hs
+++ b/src/Codec/Xlsx/Types/Internal/SharedStringTable.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE DeriveGeneric #-}
 module Codec.Xlsx.Types.Internal.SharedStringTable (
     -- * Main types
     SharedStringTable(..)

--- a/src/Codec/Xlsx/Types/Internal/SharedStringTable.hs
+++ b/src/Codec/Xlsx/Types/Internal/SharedStringTable.hs
@@ -47,7 +47,7 @@ import           Codec.Xlsx.Writer.Internal
 newtype SharedStringTable = SharedStringTable {
     sstTable :: Vector XlsxText
   }
-  deriving (Show, Eq, Ord)
+  deriving (Eq, Ord, Show, Generic)
 
 sstEmpty :: SharedStringTable
 sstEmpty = SharedStringTable V.empty

--- a/src/Codec/Xlsx/Types/PageSetup.hs
+++ b/src/Codec/Xlsx/Types/PageSetup.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell   #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE DeriveGeneric #-}
 module Codec.Xlsx.Types.PageSetup (
     -- * Main types
     PageSetup(..)

--- a/src/Codec/Xlsx/Types/PageSetup.hs
+++ b/src/Codec/Xlsx/Types/PageSetup.hs
@@ -134,7 +134,7 @@ data PageSetup = PageSetup {
     -- | Vertical print resolution of the device.
   , _pageSetupVerticalDpi :: Maybe Int
   }
-  deriving (Show, Eq, Ord)
+  deriving (Eq, Ord, Show, Generic)
 
 {-------------------------------------------------------------------------------
   Enumerations
@@ -155,7 +155,7 @@ data CellComments =
 
     -- | Do not print cell comments
   | CellCommentsNone
-  deriving (Show, Eq, Ord)
+  deriving (Eq, Ord, Show, Generic)
 
 -- | Print errors
 --
@@ -173,14 +173,14 @@ data PrintErrors =
 
      -- | Display cell errors as @#N/A@
    | PrintErrorsNA
-  deriving (Show, Eq, Ord)
+  deriving (Eq, Ord, Show, Generic)
 
 -- | Print orientation for this sheet
 data Orientation =
     OrientationDefault
   | OrientationLandscape
   | OrientationPortrait
-  deriving (Show, Eq, Ord)
+  deriving (Eq, Ord, Show, Generic)
 
 -- | Specifies printed page order
 data PageOrder =
@@ -189,7 +189,7 @@ data PageOrder =
 
     -- | Order pages horizontally first, then move vertically
   | PageOrderOverThenDown
-  deriving (Show, Eq, Ord)
+  deriving (Eq, Ord, Show, Generic)
 
 -- | Paper size
 data PaperSize =
@@ -259,7 +259,7 @@ data PaperSize =
   | EnvelopeInvite               -- ^ Invite envelope (220 mm by 220 mm)
   | EnvelopeItaly                -- ^ Italy envelope (110 mm by 230 mm)
   | EnvelopeMonarch              -- ^ Monarch envelope (3.875 in. by 7.5 in.).
-  deriving (Show, Eq, Ord)
+  deriving (Eq, Ord, Show, Generic)
 
 {-------------------------------------------------------------------------------
   Default instances

--- a/src/Codec/Xlsx/Types/PageSetup.hs
+++ b/src/Codec/Xlsx/Types/PageSetup.hs
@@ -35,6 +35,8 @@ module Codec.Xlsx.Types.PageSetup (
   , pageSetupVerticalDpi
   ) where
 
+import GHC.Generics (Generic)
+
 import Control.Lens (makeLenses)
 import Data.Default
 import Data.Maybe (catMaybes)

--- a/src/Codec/Xlsx/Types/PivotTable.hs
+++ b/src/Codec/Xlsx/Types/PivotTable.hs
@@ -11,6 +11,8 @@ module Codec.Xlsx.Types.PivotTable
   , ConsolidateFunction(..)
   ) where
 
+import GHC.Generics (Generic)
+
 import Control.Arrow (first)
 import Data.Text (Text)
 

--- a/src/Codec/Xlsx/Types/PivotTable.hs
+++ b/src/Codec/Xlsx/Types/PivotTable.hs
@@ -31,14 +31,14 @@ data PivotTable = PivotTable
   , _pvtLocation :: CellRef
   , _pvtSrcSheet :: Text
   , _pvtSrcRef :: Range
-  } deriving (Eq, Show)
+  } deriving (Eq, Show, Generic)
 
 data PivotFieldInfo = PivotFieldInfo
   { _pfiName :: PivotFieldName
   , _pfiOutline :: Bool
   , _pfiSortType :: FieldSortType
   , _pfiHiddenItems :: [CellValue]
-  } deriving (Eq, Show)
+  } deriving (Eq, Show, Generic)
 
 -- | Sort orders that can be applied to fields in a PivotTable
 --
@@ -47,22 +47,22 @@ data FieldSortType
   = FieldSortAscending
   | FieldSortDescending
   | FieldSortManual
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
 
 newtype PivotFieldName =
   PivotFieldName Text
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
 
 data PositionedField
   = DataPosition
   | FieldPosition PivotFieldName
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
 
 data DataField = DataField
   { _dfField :: PivotFieldName
   , _dfName :: Text
   , _dfFunction :: ConsolidateFunction
-  } deriving (Eq, Show)
+  } deriving (Eq, Show, Generic)
 
 -- | Data consolidation functions specified by the user and used to
 -- consolidate ranges of data
@@ -99,7 +99,7 @@ data ConsolidateFunction
   | ConsolidateVarP
     -- ^ The variance of a population, where the population is all of
     -- the data to be summarized.
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic)
 
 {-------------------------------------------------------------------------------
   Rendering

--- a/src/Codec/Xlsx/Types/PivotTable.hs
+++ b/src/Codec/Xlsx/Types/PivotTable.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE DeriveGeneric #-}
 module Codec.Xlsx.Types.PivotTable
   ( PivotTable(..)
   , PivotFieldName(..)

--- a/src/Codec/Xlsx/Types/PivotTable/Internal.hs
+++ b/src/Codec/Xlsx/Types/PivotTable/Internal.hs
@@ -20,12 +20,12 @@ import Codec.Xlsx.Types.Common
 import Codec.Xlsx.Types.PivotTable
 import Codec.Xlsx.Writer.Internal
 
-newtype CacheId = CacheId Int deriving Eq
+newtype CacheId = CacheId Int deriving (Eq, Generic)
 
 data CacheField = CacheField
   { cfName :: PivotFieldName
   , cfItems :: [CellValue]
-  } deriving (Eq, Show)
+  } deriving (Eq, Show, Generic)
 
 {-------------------------------------------------------------------------------
   Parsing

--- a/src/Codec/Xlsx/Types/PivotTable/Internal.hs
+++ b/src/Codec/Xlsx/Types/PivotTable/Internal.hs
@@ -7,6 +7,8 @@ module Codec.Xlsx.Types.PivotTable.Internal
   , CacheField(..)
   ) where
 
+import GHC.Generics (Generic)
+
 import Control.Arrow (first)
 import Data.Maybe (catMaybes)
 import Text.XML

--- a/src/Codec/Xlsx/Types/PivotTable/Internal.hs
+++ b/src/Codec/Xlsx/Types/PivotTable/Internal.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE DeriveGeneric #-}
 module Codec.Xlsx.Types.PivotTable.Internal
   ( CacheId(..)
   , CacheField(..)

--- a/src/Codec/Xlsx/Types/Protection.hs
+++ b/src/Codec/Xlsx/Types/Protection.hs
@@ -28,6 +28,8 @@ module Codec.Xlsx.Types.Protection
   , sprSelectUnlockedCells
   ) where
 
+import GHC.Generics (Generic)
+
 import Control.Arrow (first)
 import Control.Lens (makeLenses)
 import Data.Bits

--- a/src/Codec/Xlsx/Types/Protection.hs
+++ b/src/Codec/Xlsx/Types/Protection.hs
@@ -43,7 +43,7 @@ import Codec.Xlsx.Writer.Internal
 
 newtype LegacyPassword =
   LegacyPassword Text
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic)
 
 -- | Creates legacy @XOR@ hashed password.
 --
@@ -125,7 +125,7 @@ data SheetProtection = SheetProtection
     -- sheet is protected
   , _sprSort :: Bool
     -- ^ sorting should not be allowed when the sheet is protected
-  } deriving (Eq, Show)
+  } deriving (Eq, Show, Generic)
 
 makeLenses ''SheetProtection
 

--- a/src/Codec/Xlsx/Types/Protection.hs
+++ b/src/Codec/Xlsx/Types/Protection.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE DeriveGeneric #-}
 module Codec.Xlsx.Types.Protection
   ( SheetProtection(..)
   , fullSheetProtection

--- a/src/Codec/Xlsx/Types/RichText.hs
+++ b/src/Codec/Xlsx/Types/RichText.hs
@@ -66,7 +66,7 @@ data RichTextRun = RichTextRun {
     -- Section 18.4.12, "t (Text)" (p. 1727)
   , _richTextRunText :: Text
   }
-  deriving (Show, Eq, Ord)
+  deriving (Eq, Ord, Show, Generic)
 
 -- | Run properties
 --
@@ -171,7 +171,7 @@ data RunProperties = RunProperties {
     -- Section 18.4.14, "vertAlign (Vertical Alignment)" (p. 1728)
   , _runPropertiesVertAlign :: Maybe FontVerticalAlignment
   }
-  deriving (Show, Eq, Ord)
+  deriving (Eq, Ord, Show, Generic)
 
 {-------------------------------------------------------------------------------
   Lenses

--- a/src/Codec/Xlsx/Types/RichText.hs
+++ b/src/Codec/Xlsx/Types/RichText.hs
@@ -30,6 +30,8 @@ module Codec.Xlsx.Types.RichText (
   , runPropertiesVertAlign
   ) where
 
+import GHC.Generics (Generic)
+
 import Control.Lens hiding (element)
 import Control.Monad
 import Data.Default

--- a/src/Codec/Xlsx/Types/RichText.hs
+++ b/src/Codec/Xlsx/Types/RichText.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE RecordWildCards    #-}
 {-# LANGUAGE TemplateHaskell    #-}
+{-# LANGUAGE DeriveGeneric #-}
 module Codec.Xlsx.Types.RichText (
     -- * Main types
     RichTextRun(..)

--- a/src/Codec/Xlsx/Types/SheetViews.hs
+++ b/src/Codec/Xlsx/Types/SheetViews.hs
@@ -47,6 +47,8 @@ module Codec.Xlsx.Types.SheetViews (
   , paneYSplit
   ) where
 
+import GHC.Generics (Generic)
+
 import Control.Lens (makeLenses)
 import Data.Default
 import Data.Maybe (catMaybes, maybeToList, listToMaybe)

--- a/src/Codec/Xlsx/Types/SheetViews.hs
+++ b/src/Codec/Xlsx/Types/SheetViews.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
 {-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE DeriveGeneric #-}
 module Codec.Xlsx.Types.SheetViews (
     -- * Structured type to construct 'SheetViews'
     SheetView(..)

--- a/src/Codec/Xlsx/Types/SheetViews.hs
+++ b/src/Codec/Xlsx/Types/SheetViews.hs
@@ -176,7 +176,7 @@ data SheetView = SheetView {
     -- Minimum of 0, maximum of 4 elements
   , _sheetViewSelection :: [Selection]
   }
-  deriving (Show, Eq, Ord)
+  deriving (Eq, Ord, Show, Generic)
 
 -- | Worksheet view selection.
 --
@@ -199,7 +199,7 @@ data Selection = Selection {
     -- | Range of the selection. Can be non-contiguous set of ranges.
   , _selectionSqref :: Maybe SqRef
   }
-  deriving (Show, Eq, Ord)
+  deriving (Eq, Ord, Show, Generic)
 
 -- | Worksheet view pane
 --
@@ -226,7 +226,7 @@ data Pane = Pane {
     -- the left pane.
   , _paneYSplit :: Maybe Double
   }
-  deriving (Show, Eq, Ord)
+  deriving (Eq, Ord, Show, Generic)
 
 {-------------------------------------------------------------------------------
   Enumerations
@@ -244,7 +244,7 @@ data SheetViewType =
 
     -- | Page layout view
   | SheetViewTypePageLayout
-  deriving (Show, Eq, Ord)
+  deriving (Eq, Ord, Show, Generic)
 
 -- | Pane type
 --
@@ -277,7 +277,7 @@ data PaneType =
     -- dividing the pane into right and left regions. In that case, this value
     -- specifies the right pane.
   | PaneTypeTopRight
-  deriving (Eq, Show, Ord)
+  deriving (Eq, Ord, Show, Generic)
 
 -- | State of the sheet's pane.
 --
@@ -295,7 +295,7 @@ data PaneState =
     -- | Panes are split, but not frozen. In this state, the split bars are
     -- adjustable by the user.
   | PaneStateSplit
-  deriving (Eq, Show, Ord)
+  deriving (Eq, Ord, Show, Generic)
 
 {-------------------------------------------------------------------------------
   Lenses

--- a/src/Codec/Xlsx/Types/StyleSheet.hs
+++ b/src/Codec/Xlsx/Types/StyleSheet.hs
@@ -127,6 +127,8 @@ module Codec.Xlsx.Types.StyleSheet (
   , firstUserNumFmtId
   ) where
 
+import GHC.Generics (Generic)
+
 import           Control.Lens                         hiding (element, elements,
                                                        (.=))
 import           Data.Default

--- a/src/Codec/Xlsx/Types/StyleSheet.hs
+++ b/src/Codec/Xlsx/Types/StyleSheet.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
 {-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE DeriveGeneric #-}
 -- | Support for writing (but not reading) style sheets
 module Codec.Xlsx.Types.StyleSheet (
     -- * The main two types

--- a/src/Codec/Xlsx/Types/StyleSheet.hs
+++ b/src/Codec/Xlsx/Types/StyleSheet.hs
@@ -229,7 +229,7 @@ data StyleSheet = StyleSheet
     -- This element contains custom number formats defined in this style sheet
     --
     -- Section 18.8.31, "numFmts (Number Formats)" (p. 1784)
-    } deriving (Eq, Ord, Show)
+    } deriving (Eq, Ord, Show, Generic)
 
 -- | Cell formatting
 --
@@ -316,7 +316,7 @@ data CellXf = CellXf {
     -- not take effect unless the sheet has been protected.
   , _cellXfProtection        :: Maybe Protection
   }
-  deriving (Show, Eq, Ord)
+  deriving (Eq, Ord, Show, Generic)
 
 {-------------------------------------------------------------------------------
   Supporting record types
@@ -365,7 +365,7 @@ data Alignment = Alignment {
     -- within the cell.
   , _alignmentWrapText        :: Maybe Bool
   }
-  deriving (Show, Eq, Ord)
+  deriving (Eq, Ord, Show, Generic)
 
 -- | Expresses a single set of cell border formats (left, right, top, bottom,
 -- diagonal). Color is optional. When missing, 'automatic' is implied.
@@ -423,7 +423,7 @@ data Border = Border {
     -- | Vertical inner border
   , _borderVertical     :: Maybe BorderStyle
   }
-  deriving (Show, Eq, Ord)
+  deriving (Eq, Ord, Show, Generic)
 
 -- | Border style
 -- See @CT_BorderPr@ (p. 3934)
@@ -431,7 +431,7 @@ data BorderStyle = BorderStyle {
     _borderStyleColor :: Maybe Color
   , _borderStyleLine  :: Maybe LineStyle
   }
-  deriving (Show, Eq, Ord)
+  deriving (Eq, Ord, Show, Generic)
 
 -- | One of the colors associated with the data bar or color scale.
 --
@@ -465,7 +465,7 @@ data Color = Color {
     -- 100% darken and 1.0 means 100% lighten. Also, 0.0 means no change.
   , _colorTint      :: Maybe Double
   }
-  deriving (Show, Eq, Ord)
+  deriving (Eq, Ord, Show, Generic)
 
 -- | This element specifies fill formatting.
 --
@@ -477,7 +477,7 @@ data Color = Color {
 data Fill = Fill {
     _fillPattern :: Maybe FillPattern
   }
-  deriving (Show, Eq, Ord)
+  deriving (Eq, Ord, Show, Generic)
 
 -- | This element is used to specify cell fill information for pattern and solid
 -- color cell fills. For solid cell fills (no pattern), fgColor is used. For
@@ -490,7 +490,7 @@ data FillPattern = FillPattern {
   , _fillPatternFgColor :: Maybe Color
   , _fillPatternType    :: Maybe PatternType
   }
-  deriving (Show, Eq, Ord)
+  deriving (Eq, Ord, Show, Generic)
 
 -- | This element defines the properties for one of the fonts used in this
 -- workbook.
@@ -592,7 +592,7 @@ data Font = Font {
     -- is available) accordingly.
   , _fontVertAlign     :: Maybe FontVerticalAlignment
   }
-  deriving (Show, Eq, Ord)
+  deriving (Eq, Ord, Show, Generic)
 
 -- | A single dxf record, expressing incremental formatting to be applied.
 --
@@ -605,7 +605,7 @@ data Dxf = Dxf
     , _dxfBorder     :: Maybe Border
     , _dxfProtection :: Maybe Protection
     -- TODO: extList
-    } deriving (Eq, Ord, Show)
+    } deriving (Eq, Ord, Show, Generic)
 
 type NumFmt = Text
 
@@ -616,7 +616,7 @@ type NumFmt = Text
 data NumberFormat
     = StdNumberFormat ImpliedNumberFormat
     | UserNumberFormat NumFmt
-    deriving (Eq, Ord, Show)
+    deriving (Eq, Ord, Show, Generic)
 
 -- | Basic number format with predefined number of decimals
 -- as format code of number format in xlsx should be less than 255 characters
@@ -665,7 +665,7 @@ data ImpliedNumberFormat =
   | NfExponent1Decimal                -- ^> 48 ##0.0E+0
   | NfTextPlaceHolder                 -- ^> 49 @
   | NfOtherImplied Int                -- ^ other (non local-neutral?) built-in format (id < 164)
-  deriving (Show, Eq, Ord)
+  deriving (Eq, Ord, Show, Generic)
 
 stdNumberFormatId :: ImpliedNumberFormat -> Int
 stdNumberFormatId NfGeneral                         = 0 -- General
@@ -743,7 +743,7 @@ data Protection = Protection {
     _protectionHidden :: Maybe Bool
   , _protectionLocked :: Maybe Bool
   }
-  deriving (Show, Eq, Ord)
+  deriving (Eq, Ord, Show, Generic)
 
 {-------------------------------------------------------------------------------
   Enumerations
@@ -761,7 +761,7 @@ data CellHorizontalAlignment =
   | CellHorizontalAlignmentJustify
   | CellHorizontalAlignmentLeft
   | CellHorizontalAlignmentRight
-  deriving (Show, Eq, Ord)
+  deriving (Eq, Ord, Show, Generic)
 
 -- | Vertical alignment in cells
 --
@@ -772,7 +772,7 @@ data CellVerticalAlignment =
   | CellVerticalAlignmentDistributed
   | CellVerticalAlignmentJustify
   | CellVerticalAlignmentTop
-  deriving (Show, Eq, Ord)
+  deriving (Eq, Ord, Show, Generic)
 
 -- | Font family
 --
@@ -796,7 +796,7 @@ data FontFamily =
 
     -- | Novelty font
   | FontFamilyDecorative
-  deriving (Show, Eq, Ord)
+  deriving (Eq, Ord, Show, Generic)
 
 -- | Font scheme
 --
@@ -810,7 +810,7 @@ data FontScheme =
 
     -- | This font is not a theme font.
   | FontSchemeNone
-  deriving (Show, Eq, Ord)
+  deriving (Eq, Ord, Show, Generic)
 
 -- | Font underline property
 --
@@ -821,7 +821,7 @@ data FontUnderline =
   | FontUnderlineSingleAccounting
   | FontUnderlineDoubleAccounting
   | FontUnderlineNone
-  deriving (Show, Eq, Ord)
+  deriving (Eq, Ord, Show, Generic)
 
 -- | Vertical alignment
 --
@@ -830,7 +830,7 @@ data FontVerticalAlignment =
     FontVerticalAlignmentBaseline
   | FontVerticalAlignmentSubscript
   | FontVerticalAlignmentSuperscript
-  deriving (Show, Eq, Ord)
+  deriving (Eq, Ord, Show, Generic)
 
 data LineStyle =
     LineStyleDashDot
@@ -847,7 +847,7 @@ data LineStyle =
   | LineStyleSlantDashDot
   | LineStyleThick
   | LineStyleThin
-  deriving (Show, Eq, Ord)
+  deriving (Eq, Ord, Show, Generic)
 
 -- | Indicates the style of fill pattern being used for a cell format.
 --
@@ -872,7 +872,7 @@ data PatternType =
   | PatternTypeMediumGray
   | PatternTypeNone
   | PatternTypeSolid
-  deriving (Show, Eq, Ord)
+  deriving (Eq, Ord, Show, Generic)
 
 -- | Reading order
 --
@@ -881,7 +881,7 @@ data ReadingOrder =
     ReadingOrderContextDependent
   | ReadingOrderLeftToRight
   | ReadingOrderRightToLeft
-  deriving (Show, Eq, Ord)
+  deriving (Eq, Ord, Show, Generic)
 
 {-------------------------------------------------------------------------------
   Lenses

--- a/src/Codec/Xlsx/Types/Table.hs
+++ b/src/Codec/Xlsx/Types/Table.hs
@@ -5,6 +5,8 @@
 {-# LANGUAGE DeriveGeneric #-}
 module Codec.Xlsx.Types.Table where
 
+import GHC.Generics (Generic)
+
 import Control.Lens (makeLenses)
 import Data.Maybe (maybeToList)
 import Data.Text (Text)

--- a/src/Codec/Xlsx/Types/Table.hs
+++ b/src/Codec/Xlsx/Types/Table.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE DeriveGeneric #-}
 module Codec.Xlsx.Types.Table where
 
 import Control.Lens (makeLenses)

--- a/src/Codec/Xlsx/Types/Table.hs
+++ b/src/Codec/Xlsx/Types/Table.hs
@@ -59,7 +59,7 @@ data Table = Table
     -- ^ columns of this table, specification requires any table to
     -- include at least 1 column
   , tblAutoFilter :: Maybe AutoFilter
-  } deriving (Eq, Show)
+  } deriving (Eq, Show, Generic)
 
 -- | Single table column
 --
@@ -72,7 +72,7 @@ data TableColumn = TableColumn
   -- column. This is what shall be displayed in the header row in the
   -- UI, and is referenced through functions. This name shall be
   -- unique per table.
-  } deriving (Eq, Show)
+  } deriving (Eq, Show, Generic)
 
 makeLenses ''Table
 

--- a/src/Codec/Xlsx/Types/Variant.hs
+++ b/src/Codec/Xlsx/Types/Variant.hs
@@ -2,6 +2,8 @@
 {-# LANGUAGE DeriveGeneric #-}
 module Codec.Xlsx.Types.Variant where
 
+import GHC.Generics (Generic)
+
 import           Data.ByteString            (ByteString)
 import           Data.ByteString.Base64     as B64
 import           Data.Text                  (Text)

--- a/src/Codec/Xlsx/Types/Variant.hs
+++ b/src/Codec/Xlsx/Types/Variant.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveGeneric #-}
 module Codec.Xlsx.Types.Variant where
 
 import           Data.ByteString            (ByteString)

--- a/src/Codec/Xlsx/Types/Variant.hs
+++ b/src/Codec/Xlsx/Types/Variant.hs
@@ -22,7 +22,7 @@ data Variant
     -- vt_i4, vt_i8, vt_ui1, vt_ui2, vt_ui4, vt_ui8, vt_uint, vt_r4, vt_r8,
     -- vt_lpstr, vt_bstr, vt_date, vt_filetime, vt_cy, vt_error, vt_stream,
     -- vt_ostream, vt_storage, vt_ostorage, vt_vstream, vt_clsid
-    deriving (Eq, Show)
+    deriving (Eq, Show, Generic)
 
 {-------------------------------------------------------------------------------
   Parsing

--- a/src/Codec/Xlsx/Writer.hs
+++ b/src/Codec/Xlsx/Writer.hs
@@ -408,13 +408,13 @@ appXml sheetNames =
 data XlsxCellData = XlsxSS Int
                   | XlsxDouble Double
                   | XlsxBool Bool
-                    deriving (Show, Eq)
+                    deriving (Eq, Show, Generic)
 data XlsxCell = XlsxCell
     { xlsxCellStyle   :: Maybe Int
     , xlsxCellValue   :: Maybe XlsxCellData
     , xlsxComment     :: Maybe Comment
     , xlsxCellFormula :: Maybe CellFormula
-    } deriving (Show, Eq)
+    } deriving (Eq, Show, Generic)
 
 xlsxCellType :: XlsxCell -> Text
 xlsxCellType XlsxCell{xlsxCellValue=Just(XlsxSS _)} = "s"

--- a/src/Codec/Xlsx/Writer.hs
+++ b/src/Codec/Xlsx/Writer.hs
@@ -8,6 +8,8 @@ module Codec.Xlsx.Writer
     ( fromXlsx
     ) where
 
+import GHC.Generics (Generic)
+
 import qualified Codec.Archive.Zip                           as Zip
 import           Control.Arrow                               (second)
 import           Control.Lens                                hiding (transform, (.=))

--- a/src/Codec/Xlsx/Writer.hs
+++ b/src/Codec/Xlsx/Writer.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TupleSections #-}
+{-# LANGUAGE DeriveGeneric #-}
 -- | This module provides a function for serializing structured `Xlsx` into lazy bytestring
 module Codec.Xlsx.Writer
     ( fromXlsx

--- a/src/Codec/Xlsx/Writer/Internal.hs
+++ b/src/Codec/Xlsx/Writer/Internal.hs
@@ -38,6 +38,8 @@ module Codec.Xlsx.Writer.Internal (
   , justFalse
   ) where
 
+import GHC.Generics (Generic)
+
 import           Data.Text                        (Text)
 import qualified Data.Text                        as T
 import           Data.Text.Lazy                   (toStrict)

--- a/src/Codec/Xlsx/Writer/Internal.hs
+++ b/src/Codec/Xlsx/Writer/Internal.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE DeriveGeneric #-}
 module Codec.Xlsx.Writer.Internal (
     -- * Rendering documents
     ToDocument(..)

--- a/src/Codec/Xlsx/Writer/Internal/PivotTable.hs
+++ b/src/Codec/Xlsx/Writer/Internal/PivotTable.hs
@@ -22,13 +22,13 @@ import Codec.Xlsx.Writer.Internal
 data PivotTableFiles = PivotTableFiles
   { pvtfTable :: ByteString
   , pvtfCacheDefinition :: ByteString
-  } deriving (Eq, Show)
+  } deriving (Eq, Show, Generic)
 
 data CacheDefinition = CacheDefinition
   { cdSourceRef :: CellRef
   , cdSourceSheet :: Text
   , cdFields :: [CacheField]
-  } deriving (Eq, Show)
+  } deriving (Eq, Show, Generic)
 
 renderPivotTableFiles :: CellMap -> Int -> PivotTable -> PivotTableFiles
 renderPivotTableFiles cm cacheId t = PivotTableFiles {..}

--- a/src/Codec/Xlsx/Writer/Internal/PivotTable.hs
+++ b/src/Codec/Xlsx/Writer/Internal/PivotTable.hs
@@ -6,6 +6,8 @@ module Codec.Xlsx.Writer.Internal.PivotTable
   , renderPivotTableFiles
   ) where
 
+import GHC.Generics (Generic)
+
 import Data.ByteString.Lazy (ByteString)
 import Data.List.Extra (nubOrd)
 import qualified Data.Map as M

--- a/src/Codec/Xlsx/Writer/Internal/PivotTable.hs
+++ b/src/Codec/Xlsx/Writer/Internal/PivotTable.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE DeriveGeneric #-}
 module Codec.Xlsx.Writer.Internal.PivotTable
   ( PivotTableFiles(..)
   , renderPivotTableFiles


### PR DESCRIPTION
I just blanket-added `Generic`-deriving to all datatypes in the library. Feel free to remove `Generic` from anything that isn't exposed or relevant.

Also, you might want to add your `.stylish-haskell.yaml` file to the repo (assuming you use one), so that other people using stylish-haskell will not mess up the formatting. To keep the diff small, I intentionally disabled stylish-haskell, but you can obviously run it on all the changed files (with your desired settings) in a separate commit. If you don't use `stylish-haskell`, then consider adding a `.stylish-haskell.yaml` containing only `steps: {}` to keep diffs small.