### PR TITLE
Add cutomRowHeight to row properties

### DIFF
--- a/src/Codec/Xlsx/Parser.hs
+++ b/src/Codec/Xlsx/Parser.hs
@@ -122,9 +122,11 @@ extractSheet ar sst contentTypes caches wf = do
       parseRow c = do
         r <- fromAttribute "r" c
         let prop = RowProps
-              { rowHeight       = listToMaybe $ fromAttribute "ht" c
-              , rowCustomHeight = listToMaybe $ fromAttribute "customHeight" c
-              , rowStyle        = listToMaybe $ fromAttribute "s" c
+              { rowHeight = do h <- listToMaybe $ fromAttribute "ht" c
+                               case fromAttribute "customHeight" c of
+                                 [True] -> return $ CustomHeight    h
+                                 _      -> return $ AutomaticHeight h
+              , rowStyle  = listToMaybe $ fromAttribute "s" c
               , rowHidden =
                   case fromAttribute "hidden" c of
                     []  -> False

--- a/src/Codec/Xlsx/Parser.hs
+++ b/src/Codec/Xlsx/Parser.hs
@@ -122,13 +122,10 @@ extractSheet ar sst contentTypes caches wf = do
       parseRow c = do
         r <- fromAttribute "r" c
         let prop = RowProps
-              { rowHeight = 
-                  if fromAttribute "customHeight" c == [True]
-                  then listToMaybe $ fromAttribute "ht" c
-                  else Nothing
-              , rowStyle  =
-                  listToMaybe $ fromAttribute "s" c
-              , rowHidden  =
+              { rowHeight       = listToMaybe $ fromAttribute "ht" c
+              , rowCustomHeight = listToMaybe $ fromAttribute "customHeight" c
+              , rowStyle        = listToMaybe $ fromAttribute "s" c
+              , rowHidden =
                   case fromAttribute "hidden" c of
                     []  -> False
                     f:_ -> f

--- a/src/Codec/Xlsx/Types.hs
+++ b/src/Codec/Xlsx/Types.hs
@@ -15,6 +15,7 @@ module Codec.Xlsx.Types (
     , CellValue(..)
     , CellFormula(..)
     , Cell(..)
+    , RowHeight(..)
     , RowProperties (..)
     -- * Lenses
     -- ** Workbook
@@ -87,21 +88,26 @@ import Codec.Xlsx.Types.Table as X
 import Codec.Xlsx.Types.Variant as X
 import Codec.Xlsx.Writer.Internal
 
+-- | Height of a row in points (1/72in)
+data RowHeight
+  = CustomHeight    !Double
+    -- ^ Row height is set by the user
+  | AutomaticHeight !Double
+    -- ^ Row height is set automatically by the program
+  deriving (Eq, Ord, Show, Read, Generic)
+
 -- | Properties of a row. See §18.3.1.73 "row (Row)" for more details
 data RowProperties = RowProps
-  { rowHeight       :: Maybe Double
+  { rowHeight       :: Maybe RowHeight
     -- ^ Row height in points
-  , rowCustomHeight :: Maybe Bool
-    -- ^ Custom height of a row. If set to @Nothing@ its value will be
-    --   inferred from 'rowHeight'. True if it's set.
   , rowStyle        :: Maybe Int
+    -- ^ Style to be applied to row
   , rowHidden       :: Bool
     -- ^ Whether row is visible or not
   } deriving (Eq, Ord, Show, Read, Generic)
 
 instance Default RowProperties where
   def = RowProps { rowHeight       = Nothing
-                 , rowCustomHeight = Nothing
                  , rowStyle        = Nothing
                  , rowHidden       = False
                  }

--- a/src/Codec/Xlsx/Types.hs
+++ b/src/Codec/Xlsx/Types.hs
@@ -89,17 +89,21 @@ import Codec.Xlsx.Writer.Internal
 
 -- | Properties of a row. See §18.3.1.73 "row (Row)" for more details
 data RowProperties = RowProps
-  { rowHeight :: Maybe Double
+  { rowHeight       :: Maybe Double
     -- ^ Row height in points
-  , rowStyle  :: Maybe Int
-  , rowHidden :: Bool
+  , rowCustomHeight :: Maybe Bool
+    -- ^ Custom height of a row. If set to @Nothing@ its value will be
+    --   inferred from 'rowHeight'. True if it's set.
+  , rowStyle        :: Maybe Int
+  , rowHidden       :: Bool
     -- ^ Whether row is visible or not
   } deriving (Eq, Ord, Show, Read, Generic)
 
 instance Default RowProperties where
-  def = RowProps { rowHeight = Nothing
-                 , rowStyle  = Nothing
-                 , rowHidden = False
+  def = RowProps { rowHeight       = Nothing
+                 , rowCustomHeight = Nothing
+                 , rowStyle        = Nothing
+                 , rowHidden       = False
                  }
 
 -- | Column range (from cwMin to cwMax) properties

--- a/src/Codec/Xlsx/Writer.hs
+++ b/src/Codec/Xlsx/Writer.hs
@@ -176,10 +176,12 @@ sheetDataXml rows rh = map rowEl rows
                        $ map (cellEl r) cells
       where
         mProps    = M.lookup r rh
-        hasHeight = case rowCustomHeight =<< mProps of
-                      Just b  -> b
-                      Nothing -> isJust $ rowHeight =<< mProps
-        ht        = do Just h <- [rowHeight =<< mProps]
+        hasHeight = case rowHeight =<< mProps of
+                      Just CustomHeight{} -> True
+                      _                   -> False
+        ht        = do Just height <- [rowHeight =<< mProps]
+                       let h = case height of CustomHeight    x -> x
+                                              AutomaticHeight x -> x
                        return ("ht", txtd h)
         s         = do Just st <- [rowStyle =<< mProps]
                        return ("s", txti st)

--- a/src/Codec/Xlsx/Writer.hs
+++ b/src/Codec/Xlsx/Writer.hs
@@ -176,7 +176,9 @@ sheetDataXml rows rh = map rowEl rows
                        $ map (cellEl r) cells
       where
         mProps    = M.lookup r rh
-        hasHeight = isJust $ rowHeight =<< mProps
+        hasHeight = case rowCustomHeight =<< mProps of
+                      Just b  -> b
+                      Nothing -> isJust $ rowHeight =<< mProps
         ht        = do Just h <- [rowHeight =<< mProps]
                        return ("ht", txtd h)
         s         = do Just st <- [rowStyle =<< mProps]

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -100,8 +100,7 @@ testXlsx = Xlsx sheets minimalStyles definedNames customProperties
     sheet2 = def & wsCells .~ testCellMap2
     pvSheet = sheetWithPvCells & wsPivotTables .~ [testPivotTable]
     sheetWithPvCells = def & wsCells .~ testPivotSrcCells
-    rowProps = M.fromList [(1, RowProps { rowHeight       = Just 50
-                                        , rowCustomHeight = Just True
+    rowProps = M.fromList [(1, RowProps { rowHeight       = Just (CustomHeight 50)
                                         , rowStyle        = Just 3
                                         , rowHidden       = False
                                         })]

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -100,7 +100,11 @@ testXlsx = Xlsx sheets minimalStyles definedNames customProperties
     sheet2 = def & wsCells .~ testCellMap2
     pvSheet = sheetWithPvCells & wsPivotTables .~ [testPivotTable]
     sheetWithPvCells = def & wsCells .~ testPivotSrcCells
-    rowProps = M.fromList [(1, RowProps (Just 50) (Just 3) False)]
+    rowProps = M.fromList [(1, RowProps { rowHeight       = Just 50
+                                        , rowCustomHeight = Just True
+                                        , rowStyle        = Just 3
+                                        , rowHidden       = False
+                                        })]
     cols = [ColumnsProperties 1 10 (Just 15) (Just 1) False False False]
     drawing = Just $ testDrawing { _xdrAnchors = map resolve $ _xdrAnchors testDrawing }
     resolve :: Anchor RefId RefId -> Anchor FileInfo ChartSpace


### PR DESCRIPTION
Row height could be set either by user in which case customnHeight=true
or by adding text with large font size in which case customHeight=false.
If customHeight=false editor is free to resize row as it see fit. To
correctly export xlsx with large fornt we need access to customHeight

This of course breaks user code since now height is present even if 
height is not set by user. Another option is to change height to `Maybe (Impicit | UserSet)`
