### PR TITLE
Changes for GHC 8.8.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,16 +26,6 @@ matrix:
   include:
   # The Stack builds. We can pass in arbitrary Stack arguments via the ARGS
   # variable, such as using --stack-yaml to point to a different file.
-  - env: BUILD=stack ARGS="--stack-yaml=stack-lts-6.yaml" GHCVER=7.10.3 HAPPYVER=1.19.4
-    compiler: ": #stack 7.10.3"
-    addons:
-      apt:
-        sources:
-        - hvr-ghc
-        packages:
-        - ghc-7.10.3
-        - happy-1.19.4
-
   - env: BUILD=stack ARGS="--stack-yaml=stack-lts-9.yaml" GHCVER=8.0.2 HAPPYVER=1.19.4
     compiler: ": #stack 8.0.2"
     addons:
@@ -66,16 +56,6 @@ matrix:
         - ghc-8.4.3
         - happy-1.19.4
 
-  - env: BUILD=stack ARGS="--stack-yaml=stack-lts-13.yaml" GHCVER=8.6.4 HAPPYVER=1.19.4
-    compiler: ": #stack 8.6.4"
-    addons:
-      apt:
-        sources:
-        - hvr-ghc
-        packages:
-        - ghc-8.6.4
-        - happy-1.19.4
-
   - env: BUILD=stack ARGS="--stack-yaml=stack-lts-14.yaml" GHCVER=8.6.5 HAPPYVER=1.19.4
     compiler: ": #stack 8.6.5"
     addons:
@@ -86,7 +66,7 @@ matrix:
         - ghc-8.6.5
         - happy-1.19.4
 
-  - env: BUILD=stack ARGS="--stack-yaml=stack-nigtly.yaml" GHCVER=8.8.1 HAPPYVER=1.19.4
+  - env: BUILD=stack ARGS="--stack-yaml=stack-nightly.yaml" GHCVER=8.8.1 HAPPYVER=1.19.4
     compiler: ": #stack 8.8.1"
     addons:
       apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,36 @@ matrix:
         - ghc-8.4.3
         - happy-1.19.4
 
+  - env: BUILD=stack ARGS="--stack-yaml=stack-lts-13.yaml" GHCVER=8.6.4 HAPPYVER=1.19.4
+    compiler: ": #stack 8.6.4"
+    addons:
+      apt:
+        sources:
+        - hvr-ghc
+        packages:
+        - ghc-8.6.4
+        - happy-1.19.4
+
+  - env: BUILD=stack ARGS="--stack-yaml=stack-lts-14.yaml" GHCVER=8.6.5 HAPPYVER=1.19.4
+    compiler: ": #stack 8.6.5"
+    addons:
+      apt:
+        sources:
+        - hvr-ghc
+        packages:
+        - ghc-8.6.5
+        - happy-1.19.4
+
+  - env: BUILD=stack ARGS="--stack-yaml=stack-nigtly.yaml" GHCVER=8.8.1 HAPPYVER=1.19.4
+    compiler: ": #stack 8.8.1"
+    addons:
+      apt:
+        sources:
+        - hvr-ghc
+        packages:
+        - ghc-8.8.1
+        - happy-1.19.4
+
 before_install:
 # Using compiler above sets CC to an invalid value, so unset it
 - unset CC

--- a/src/Codec/Xlsx/Parser/Internal/Fast.hs
+++ b/src/Codec/Xlsx/Parser/Internal/Fast.hs
@@ -35,6 +35,7 @@ import Control.Applicative
 import Control.Arrow (second)
 import Control.Exception (Exception, throw)
 import Control.Monad (ap, forM, join, liftM)
+import Data.Bifunctor (first)
 import Data.Bits ((.|.), shiftL)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
@@ -224,18 +225,14 @@ instance FromAttrBs Bool where
 instance FromAttrBs Int where
   -- it appears that parser in text is more optimized than the one in
   -- attoparsec at least as of text-1.2.2.2 and attoparsec-0.13.1.0
-  fromAttrBs = mapLeft T.pack . eitherDecimal . T.decodeLatin1
+  fromAttrBs = first T.pack . eitherDecimal . T.decodeLatin1
 
 instance FromAttrBs Double where
   -- as for rationals
-  fromAttrBs = mapLeft T.pack . eitherRational . T.decodeLatin1
+  fromAttrBs = first T.pack . eitherRational . T.decodeLatin1
 
 instance FromAttrBs Text where
   fromAttrBs = replaceEntititesBs
-
-mapLeft :: (a -> c) -> Either a b -> Either c b
-mapLeft f (Left a) = Left $ f a
-mapLeft _ (Right b) = Right b
 
 replaceEntititesBs :: ByteString -> Either Text Text
 replaceEntititesBs str =

--- a/src/Codec/Xlsx/Parser/Internal/Fast.hs
+++ b/src/Codec/Xlsx/Parser/Internal/Fast.hs
@@ -40,6 +40,7 @@ import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Unsafe as SU
 import Data.Char (chr)
+import Data.Either.Extra (mapLeft)
 import Data.Maybe
 import Data.Monoid ((<>))
 import Data.Text (Text)
@@ -224,11 +225,11 @@ instance FromAttrBs Bool where
 instance FromAttrBs Int where
   -- it appears that parser in text is more optimized than the one in
   -- attoparsec at least as of text-1.2.2.2 and attoparsec-0.13.1.0
-  fromAttrBs = decimal . T.decodeLatin1
+  fromAttrBs = mapLeft T.pack . eitherDecimal . T.decodeLatin1
 
 instance FromAttrBs Double where
   -- as for rationals
-  fromAttrBs = rational . T.decodeLatin1
+  fromAttrBs = mapLeft T.pack . eitherRational . T.decodeLatin1
 
 instance FromAttrBs Text where
   fromAttrBs = replaceEntititesBs

--- a/src/Codec/Xlsx/Parser/Internal/Fast.hs
+++ b/src/Codec/Xlsx/Parser/Internal/Fast.hs
@@ -40,7 +40,6 @@ import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Unsafe as SU
 import Data.Char (chr)
-import Data.Either.Extra (mapLeft)
 import Data.Maybe
 import Data.Monoid ((<>))
 import Data.Text (Text)
@@ -233,6 +232,10 @@ instance FromAttrBs Double where
 
 instance FromAttrBs Text where
   fromAttrBs = replaceEntititesBs
+
+mapLeft :: (a -> c) -> Either a b -> Either c b
+mapLeft f (Left a) = Left $ f a
+mapLeft _ (Right b) = Right b
 
 replaceEntititesBs :: ByteString -> Either Text Text
 replaceEntititesBs str =

--- a/src/Codec/Xlsx/Parser/Internal/Util.hs
+++ b/src/Codec/Xlsx/Parser/Internal/Util.hs
@@ -19,7 +19,7 @@ decimal = fromEither . eitherDecimal
 eitherDecimal :: (Integral a) => Text -> Either String a
 eitherDecimal t = case T.signed T.decimal t of
   Right (d, leftover) | T.null leftover -> Right d
-  _ -> Left $ "invalid decimal" ++ show t
+  _ -> Left $ "invalid decimal: " ++ show t
 
 rational :: (MonadFail m) => Text -> m Double
 rational = fromEither . eitherRational

--- a/src/Codec/Xlsx/Parser/Internal/Util.hs
+++ b/src/Codec/Xlsx/Parser/Internal/Util.hs
@@ -1,26 +1,48 @@
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE CPP #-}
 module Codec.Xlsx.Parser.Internal.Util
   ( boolean
+  , eitherBoolean
   , decimal
+  , eitherDecimal
   , rational
+  , eitherRational
   ) where
 
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Read as T
 
-decimal :: (Monad m, Integral a) => Text -> m a
-decimal t = case T.signed T.decimal $ t of
+#if (MIN_VERSION_base(4,13,0))
+#define FAIL_MONAD MonadFail
+#else
+#define FAIL_MONAD Monad
+#endif
+
+decimal :: (FAIL_MONAD m, Integral a) => Text -> m a
+decimal = fromEither . eitherDecimal
+
+eitherDecimal :: (Integral a) => Text -> Either String a
+eitherDecimal t = case T.signed T.decimal t of
   Right (d, leftover) | T.null leftover -> return d
-  _ -> fail $ "invalid decimal" ++ show t
+  _ -> Left $ "invalid decimal" ++ show t
 
-rational :: Monad m => Text -> m Double
-rational t = case T.signed T.rational t of
+rational :: (FAIL_MONAD m) => Text -> m Double
+rational = fromEither . eitherRational
+
+eitherRational :: Text -> Either String Double
+eitherRational t = case T.signed T.rational t of
   Right (r, leftover) | T.null leftover -> return r
-  _ -> fail $ "invalid rational: " ++ show t
+  _ -> Left $ "invalid rational: " ++ show t
 
-boolean :: Monad m => Text -> m Bool
-boolean t = case T.strip t of
+boolean :: (FAIL_MONAD m) => Text -> m Bool
+boolean = fromEither . eitherBoolean
+
+eitherBoolean :: Text -> Either String Bool
+eitherBoolean t = case T.unpack $ T.strip t of
     "true"  -> return True
     "false" -> return False
-    _       -> fail $ "invalid boolean: " ++ show t
+    _       -> Left $ "invalid boolean: " ++ show t
+
+fromEither :: (FAIL_MONAD m) => Either String b -> m b
+fromEither (Left a) = fail a
+fromEither (Right b) = return b

--- a/src/Codec/Xlsx/Parser/Internal/Util.hs
+++ b/src/Codec/Xlsx/Parser/Internal/Util.hs
@@ -18,7 +18,7 @@ decimal = fromEither . eitherDecimal
 
 eitherDecimal :: (Integral a) => Text -> Either String a
 eitherDecimal t = case T.signed T.decimal t of
-  Right (d, leftover) | T.null leftover -> return d
+  Right (d, leftover) | T.null leftover -> Right d
   _ -> Left $ "invalid decimal" ++ show t
 
 rational :: (MonadFail m) => Text -> m Double
@@ -26,7 +26,7 @@ rational = fromEither . eitherRational
 
 eitherRational :: Text -> Either String Double
 eitherRational t = case T.signed T.rational t of
-  Right (r, leftover) | T.null leftover -> return r
+  Right (r, leftover) | T.null leftover -> Right r
   _ -> Left $ "invalid rational: " ++ show t
 
 boolean :: (MonadFail m) => Text -> m Bool
@@ -34,8 +34,8 @@ boolean = fromEither . eitherBoolean
 
 eitherBoolean :: Text -> Either String Bool
 eitherBoolean t = case T.unpack $ T.strip t of
-    "true"  -> return True
-    "false" -> return False
+    "true"  -> Right True
+    "false" -> Right False
     _       -> Left $ "invalid boolean: " ++ show t
 
 fromEither :: (MonadFail m) => Either String b -> m b

--- a/src/Codec/Xlsx/Types/Drawing/Common.hs
+++ b/src/Codec/Xlsx/Types/Drawing/Common.hs
@@ -9,6 +9,7 @@ import GHC.Generics (Generic)
 import Control.Arrow (first)
 import Control.Lens.TH
 import Control.Monad (join)
+import Control.Monad.Fail (MonadFail)
 import Control.DeepSeq (NFData)
 import Data.Default
 import Data.Maybe (catMaybes, listToMaybe)
@@ -462,7 +463,7 @@ colorChoiceFromNode n
     return $ RgbColor val
   | otherwise = fail "no matching color choice node"
 
-coordinate :: Text -> [Coordinate]
+coordinate :: MonadFail m => Text -> m Coordinate
 coordinate t =  case T.decimal t of
   Right (d, leftover) | leftover == T.empty ->
       return $ UnqCoordinate d

--- a/src/Codec/Xlsx/Types/Drawing/Common.hs
+++ b/src/Codec/Xlsx/Types/Drawing/Common.hs
@@ -462,7 +462,7 @@ colorChoiceFromNode n
     return $ RgbColor val
   | otherwise = fail "no matching color choice node"
 
-coordinate :: Monad m => Text -> m Coordinate
+coordinate :: Text -> [Coordinate]
 coordinate t =  case T.decimal t of
   Right (d, leftover) | leftover == T.empty ->
       return $ UnqCoordinate d

--- a/src/Codec/Xlsx/Types/Variant.hs
+++ b/src/Codec/Xlsx/Types/Variant.hs
@@ -52,7 +52,7 @@ variantFromNode  _ = fail "no matching nodes"
 killWhitespace :: Text -> Text
 killWhitespace = T.filter (/=' ')
 
-decodeBase64 :: Monad m => Text -> m ByteString
+decodeBase64 :: Text -> [ByteString]
 decodeBase64 t = case B64.decode (T.encodeUtf8 t) of
   Right bs -> return bs
   Left err -> fail $ "invalid base64 value: " ++ err

--- a/src/Codec/Xlsx/Types/Variant.hs
+++ b/src/Codec/Xlsx/Types/Variant.hs
@@ -3,6 +3,7 @@
 module Codec.Xlsx.Types.Variant where
 
 import Control.DeepSeq (NFData)
+import Control.Monad.Fail (MonadFail)
 import Data.ByteString (ByteString)
 import Data.ByteString.Base64 as B64
 import Data.Text (Text)
@@ -52,7 +53,7 @@ variantFromNode  _ = fail "no matching nodes"
 killWhitespace :: Text -> Text
 killWhitespace = T.filter (/=' ')
 
-decodeBase64 :: Text -> [ByteString]
+decodeBase64 :: MonadFail m => Text -> m ByteString
 decodeBase64 t = case B64.decode (T.encodeUtf8 t) of
   Right bs -> return bs
   Left err -> fail $ "invalid base64 value: " ++ err

--- a/stack-lts-13.yaml
+++ b/stack-lts-13.yaml
@@ -1,3 +1,0 @@
-resolver: lts-13.19
-packages:
-- '.'

--- a/stack-lts-13.yaml
+++ b/stack-lts-13.yaml
@@ -1,0 +1,3 @@
+resolver: lts-13.19
+packages:
+- '.'

--- a/stack-lts-14.yaml
+++ b/stack-lts-14.yaml
@@ -1,0 +1,3 @@
+resolver: lts-14.12
+packages:
+- '.'

--- a/stack-lts-6.yaml
+++ b/stack-lts-6.yaml
@@ -1,8 +1,0 @@
-resolver: lts-6.35
-packages:
-- '.'
-extra-deps:
-- xeno-0.3.2
-- bytestring-0.10.8.0
-- tagged-0.8.5
-- transformers-compat-0.5.1.4

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -1,0 +1,3 @@
+resolver: nightly-2019-10-31
+packages:
+- '.'

--- a/xlsx.cabal
+++ b/xlsx.cabal
@@ -26,7 +26,7 @@ Maintainer:          qrilka@gmail.com
 
 Category:            Codec
 Build-type:          Simple
-Tested-with:         GHC == 7.10.3, GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.3
+Tested-with:         GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.3, GHC == 8.6.5, GHC == 8.8.1
 Cabal-version:       >=1.10
 
 


### PR DESCRIPTION
`fail` has been removed from `Monad` in 8.8.1 (and moved to `MonadFail`), these are what seemed to be the minimal changes to keep xlsx working on all ghc versions in travis (i also added 8.6.5 and a nightly 8.8.1)
the reason it needed changes at all were because whilst `Either a b` is `Monad`, it is not `MonadFail`, the `fail` for `Either a b` was basically `error`, so this change also stops a possible error case in `fromAttrsBs`