### PR TITLE
microlens as an alternative to lens

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,16 @@ matrix:
         packages:
         - ghc-8.6.5
         - happy-1.19.4
+  
+  - env: BUILD=stack ARGS="--stack-yaml=stack-lts-14.yaml --flag xlsx:microlens" GHCVER=8.6.5 HAPPYVER=1.19.4
+    compiler: ": #stack 8.6.5"
+    addons:
+      apt:
+        sources:
+        - hvr-ghc
+        packages:
+        - ghc-8.6.5
+        - happy-1.19.4
 
   - env: BUILD=stack ARGS="--stack-yaml=stack-nightly.yaml" GHCVER=8.8.1 HAPPYVER=1.19.4
     compiler: ": #stack 8.8.1"
@@ -103,11 +113,11 @@ install:
 - if [ -f configure.ac ]; then autoreconf -i; fi
 - |
   set -ex
-  stack --no-terminal --skip-ghc-check -j2 $ARGS test --only-dependencies
+  stack --no-terminal --skip-ghc-check -j2 test $ARGS --only-dependencies
   set +ex
 
 script:
 - |
   set -ex
-  stack --no-terminal --skip-ghc-check -j2 $ARGS test --haddock --no-haddock-deps
+  stack --no-terminal --skip-ghc-check -j2 test $ARGS --haddock --no-haddock-deps
   set +ex

--- a/src/Codec/Xlsx/Formatted.hs
+++ b/src/Codec/Xlsx/Formatted.hs
@@ -1,4 +1,5 @@
 -- | Higher level interface for creating styled worksheets
+{-# LANGUAGE CPP      #-}
 {-# LANGUAGE RankNTypes      #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
@@ -34,7 +35,14 @@ module Codec.Xlsx.Formatted
   , condfmtStopIfTrue
   ) where
 
+#ifdef USE_MICROLENS
+import Lens.Micro
+import Lens.Micro.Mtl
+import Lens.Micro.TH
+import Lens.Micro.GHC ()
+#else
 import Control.Lens
+#endif
 import Control.Monad.State hiding (forM_, mapM)
 import Data.Default
 import Data.Foldable (asum, forM_)

--- a/src/Codec/Xlsx/Parser.hs
+++ b/src/Codec/Xlsx/Parser.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE NoMonomorphismRestriction #-}
 {-# LANGUAGE OverloadedStrings         #-}
@@ -21,7 +22,11 @@ import Control.Arrow (left)
 import Control.Error.Safe (headErr)
 import Control.Error.Util (note)
 import Control.Exception (Exception)
+#ifdef USE_MICROLENS
+import Lens.Micro
+#else
 import Control.Lens hiding ((<.>), element, views)
+#endif
 import Control.Monad (forM, join, void)
 import Control.Monad.Except (catchError, throwError)
 import Data.Bool (bool)

--- a/src/Codec/Xlsx/Types.hs
+++ b/src/Codec/Xlsx/Types.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE NoMonomorphismRestriction #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -61,7 +62,11 @@ module Codec.Xlsx.Types (
     ) where
 
 import Control.Exception (SomeException, toException)
+#ifdef USE_MICROLENS
+import Lens.Micro.TH
+#else
 import Control.Lens.TH
+#endif
 import Control.DeepSeq (NFData)
 import qualified Data.ByteString.Lazy as L
 import Data.Default
@@ -265,8 +270,7 @@ instance Default DefinedNames where
     def = DefinedNames []
 
 emptyStyles :: Styles
-emptyStyles = Styles "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\
-\<styleSheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\"></styleSheet>"
+emptyStyles = Styles "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><styleSheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\"></styleSheet>"
 
 -- | Render 'StyleSheet'
 --

--- a/src/Codec/Xlsx/Types/AutoFilter.hs
+++ b/src/Codec/Xlsx/Types/AutoFilter.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -8,7 +9,11 @@ module Codec.Xlsx.Types.AutoFilter where
 
 import Control.Arrow (first)
 import Control.DeepSeq (NFData)
+#ifdef USE_MICROLENS
+import Lens.Micro.TH (makeLenses)
+#else
 import Control.Lens (makeLenses)
+#endif
 import Data.Bool (bool)
 import Data.ByteString (ByteString)
 import Data.Default

--- a/src/Codec/Xlsx/Types/Cell.hs
+++ b/src/Codec/Xlsx/Types/Cell.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
@@ -20,7 +21,11 @@ module Codec.Xlsx.Types.Cell
   ) where
 
 import Control.Arrow (first)
+#ifdef USE_MICROLENS
+import Lens.Micro.TH (makeLenses)
+#else
 import Control.Lens.TH (makeLenses)
+#endif
 import Control.DeepSeq (NFData)
 import Data.Default
 import Data.Map (Map)

--- a/src/Codec/Xlsx/Types/ConditionalFormatting.hs
+++ b/src/Codec/Xlsx/Types/ConditionalFormatting.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -42,7 +43,11 @@ module Codec.Xlsx.Types.ConditionalFormatting
 
 import Control.Arrow (first, right)
 import Control.DeepSeq (NFData)
+#ifdef USE_MICROLENS
+import Lens.Micro.TH (makeLenses)
+#else
 import Control.Lens (makeLenses)
+#endif
 import Data.Bool (bool)
 import Data.ByteString (ByteString)
 import Data.Default

--- a/src/Codec/Xlsx/Types/DataValidation.hs
+++ b/src/Codec/Xlsx/Types/DataValidation.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -6,7 +7,11 @@
 module Codec.Xlsx.Types.DataValidation where
 
 import Control.DeepSeq (NFData)
+#ifdef USE_MICROLENS
+import Lens.Micro.TH (makeLenses)
+#else
 import Control.Lens.TH (makeLenses)
+#endif
 import Control.Monad ((>=>))
 import Data.ByteString (ByteString)
 import Data.Char (isSpace)

--- a/src/Codec/Xlsx/Types/Drawing.hs
+++ b/src/Codec/Xlsx/Types/Drawing.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -12,7 +13,11 @@ module Codec.Xlsx.Types.Drawing where
 
 import Control.Arrow (first)
 import Control.DeepSeq (NFData)
+#ifdef USE_MICROLENS
+import Lens.Micro.TH (makeLenses)
+#else
 import Control.Lens.TH
+#endif
 import Data.ByteString.Lazy (ByteString)
 import Data.Default
 import qualified Data.Map as M

--- a/src/Codec/Xlsx/Types/Drawing/Chart.hs
+++ b/src/Codec/Xlsx/Types/Drawing/Chart.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
@@ -6,7 +7,11 @@ module Codec.Xlsx.Types.Drawing.Chart where
 
 import GHC.Generics (Generic)
 
+#ifdef USE_MICROLENS
+import Lens.Micro.TH (makeLenses)
+#else
 import Control.Lens.TH
+#endif
 import Control.DeepSeq (NFData)
 import Data.Default
 import Data.Maybe (catMaybes, listToMaybe, maybeToList)

--- a/src/Codec/Xlsx/Types/Drawing/Common.hs
+++ b/src/Codec/Xlsx/Types/Drawing/Common.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
@@ -7,7 +8,11 @@ module Codec.Xlsx.Types.Drawing.Common where
 import GHC.Generics (Generic)
 
 import Control.Arrow (first)
+#ifdef USE_MICROLENS
+import Lens.Micro.TH (makeLenses)
+#else
 import Control.Lens.TH
+#endif
 import Control.Monad (join)
 import Control.Monad.Fail (MonadFail)
 import Control.DeepSeq (NFData)

--- a/src/Codec/Xlsx/Types/PageSetup.hs
+++ b/src/Codec/Xlsx/Types/PageSetup.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell   #-}
 {-# LANGUAGE RecordWildCards   #-}
@@ -34,7 +35,11 @@ module Codec.Xlsx.Types.PageSetup (
   , pageSetupVerticalDpi
   ) where
 
+#ifdef USE_MICROLENS
+import Lens.Micro.TH (makeLenses)
+#else
 import Control.Lens (makeLenses)
+#endif
 import Control.DeepSeq (NFData)
 import Data.Default
 import qualified Data.Map as Map

--- a/src/Codec/Xlsx/Types/Protection.hs
+++ b/src/Codec/Xlsx/Types/Protection.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
@@ -31,7 +32,11 @@ module Codec.Xlsx.Types.Protection
 import GHC.Generics (Generic)
 
 import Control.Arrow (first)
+#ifdef USE_MICROLENS
+import Lens.Micro.TH (makeLenses)
+#else
 import Control.Lens (makeLenses)
+#endif
 import Control.DeepSeq (NFData)
 import Data.Bits
 import Data.Char

--- a/src/Codec/Xlsx/Types/RichText.hs
+++ b/src/Codec/Xlsx/Types/RichText.hs
@@ -32,7 +32,11 @@ module Codec.Xlsx.Types.RichText (
 
 import GHC.Generics (Generic)
 
+#ifdef USE_MICROLENS
+import Lens.Micro.TH (makeLenses)
+#else
 import Control.Lens hiding (element)
+#endif
 import Control.Monad
 import Control.DeepSeq (NFData)
 import Data.Default

--- a/src/Codec/Xlsx/Types/SheetViews.hs
+++ b/src/Codec/Xlsx/Types/SheetViews.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
 {-# LANGUAGE TemplateHaskell   #-}
@@ -48,7 +49,11 @@ module Codec.Xlsx.Types.SheetViews (
 
 import GHC.Generics (Generic)
 
+#ifdef USE_MICROLENS
+import Lens.Micro.TH (makeLenses)
+#else
 import Control.Lens (makeLenses)
+#endif
 import Control.DeepSeq (NFData)
 import Data.Default
 import Data.Maybe (catMaybes, maybeToList, listToMaybe)

--- a/src/Codec/Xlsx/Types/StyleSheet.hs
+++ b/src/Codec/Xlsx/Types/StyleSheet.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
 {-# LANGUAGE TemplateHaskell   #-}
@@ -128,7 +129,12 @@ module Codec.Xlsx.Types.StyleSheet (
   , firstUserNumFmtId
   ) where
 
+#ifdef USE_MICROLENS
+import Lens.Micro
+import Lens.Micro.TH (makeLenses)
+#else
 import Control.Lens hiding (element, elements, (.=))
+#endif
 import Control.DeepSeq (NFData)
 import Data.Default
 import Data.Map.Strict (Map)

--- a/src/Codec/Xlsx/Types/Table.hs
+++ b/src/Codec/Xlsx/Types/Table.hs
@@ -1,10 +1,15 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE DeriveGeneric #-}
 module Codec.Xlsx.Types.Table where
 
+#ifdef USE_MICROLENS
+import Lens.Micro.TH (makeLenses)
+#else
 import Control.Lens (makeLenses)
+#endif
 import Control.DeepSeq (NFData)
 import Data.Maybe (catMaybes, maybeToList)
 import Data.Text (Text)

--- a/src/Codec/Xlsx/Writer.hs
+++ b/src/Codec/Xlsx/Writer.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -10,7 +11,11 @@ module Codec.Xlsx.Writer
 
 import qualified Codec.Archive.Zip as Zip
 import Control.Arrow (second)
+#ifdef USE_MICROLENS
+import Lens.Micro
+#else
 import Control.Lens hiding (transform, (.=))
+#endif
 import Control.Monad (forM)
 import Control.Monad.ST
 import Control.Monad.State (evalState, get, put)

--- a/xlsx.cabal
+++ b/xlsx.cabal
@@ -29,6 +29,10 @@ Build-type:          Simple
 Tested-with:         GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.3, GHC == 8.6.5, GHC == 8.8.1
 Cabal-version:       >=1.10
 
+Flag microlens
+  default: False
+  description: Use microlens instead of lens
+
 
 Library
   Hs-source-dirs:    src
@@ -85,7 +89,6 @@ Library
                    , errors
                    , extra
                    , filepath
-                   , lens         >= 3.8 && < 5
                    , mtl          >= 2.1
                    , network-uri
                    , old-locale   >= 1.0.0.5
@@ -98,6 +101,15 @@ Library
                    , xml-conduit  >= 1.1.0
                    , zip-archive  >= 0.2
                    , zlib         >= 0.5.4.0
+  if flag(microlens)
+    Build-depends:     microlens    >= 0.4 && < 0.5
+                     , microlens-mtl
+                     , microlens-ghc
+                     , microlens-th
+    cpp-options: -DUSE_MICROLENS
+  else
+    Build-depends:     lens         >= 3.8 && < 5
+
   Default-Language:     Haskell2010
   Other-Extensions:  DeriveDataTypeable
                      FlexibleInstances
@@ -125,7 +137,7 @@ test-suite data-test
                , containers
                , Diff >= 0.3.0
                , groom
-               , lens
+               , lens >= 3.8 && < 5
                , mtl
                , raw-strings-qq
                , smallcheck


### PR DESCRIPTION
Hi,

This is a PR addressing #129. The only changes, other than using `LANGUAGE CPP` to import microlens instead of lens are:

* In `src/Codec/Xlsx/Lens.hs`, I unfolded the defn of `sheetList` in `ixSheet` and `atSheet`, since microlens does not provide `Iso`.

* In `src/Codec/Xlsx/Types.hs` the following
  ```haskell
  emptyStyles = Styles "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\
  \<styleSheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\"></styleSheet>"
  ```
  would not play nice with the `CPP` pragma, so I moved the string onto a single line.