### PR TITLE
Fix Accumulating Cell Merge Info While formatWorkbook

### DIFF
--- a/src/Codec/Xlsx/Formatted.hs
+++ b/src/Codec/Xlsx/Formatted.hs
@@ -251,6 +251,7 @@ formatWorkbook nfcss initStyle = extract go
     initSt = stateFromStyleSheet initStyle
     go = flip runState initSt $
       forM nfcss $ \(name, fcs) -> do
+        modify (\s -> s { _formattingMerges = [] }) -- We do not want merge information to accumulate across sheets.
         cs' <- forM (M.toList fcs) $ \(rc, fc) -> formatCell rc fc
         merges <- reverse . _formattingMerges <$> get
         return ( name


### PR DESCRIPTION
This PR closes #142.

`formatWorkbook` accumulates cell merge information (`_formattingMerges`) along with style information as it iterates over a list of worksheet data.

Indeed, this is necessary for `formatCell` to process a single worksheet and to conclude with a list of cell ranges for merged cells.

However, once we are done with processing a single worksheet, we should reset the accumulated merge information to an empty list so that the next worksheet does not contain cell merges accumulated from previous worksheets' data.
