### PR TITLE
Remove attoparsec from build-depends

### DIFF
--- a/xlsx.cabal
+++ b/xlsx.cabal
@@ -78,7 +78,6 @@ Library
                    , Codec.Xlsx.Writer.Internal.PivotTable
 
   Build-depends:     base         >= 4.9.0.0 && < 5.0
-                   , attoparsec
                    , base64-bytestring
                    , binary-search
                    , bytestring   >= 0.10.8.0


### PR DESCRIPTION
`attoparsec` is not used anywhere.