### PR TITLE
Include Test Data Files in Extra Source Files

### DIFF
--- a/xlsx.cabal
+++ b/xlsx.cabal
@@ -15,6 +15,7 @@ Description:
     4th edition of the standard with the transitional schema is used for this library.
 Extra-source-files:
                      CHANGELOG.markdown
+                     data/inline-strings.xlsx
 
 
 Homepage:            https://github.com/qrilka/xlsx


### PR DESCRIPTION
Fix test runs off of the source package by including required `data/`
files in the cabal file's `Extra-source-files` field.

---

Tested it w/ the stack-nightly file but that's it.