### PR TITLE
feat(cellRange,dataValidation): add support for cell range <dataValidation type="list"> and absolute coordinates

### DIFF
--- a/src/Codec/Xlsx/Types/Common.hs
+++ b/src/Codec/Xlsx/Types/Common.hs
@@ -9,7 +9,7 @@ module Codec.Xlsx.Types.Common
   ( CellRef(..)
   , Coord(..)
   , unCoord
-  , both
+  , mapBoth
   , singleCellRef
   , singleCellRef'
   , fromSingleCellRef
@@ -116,9 +116,9 @@ unCoord (Rel i) = i
 
 -- | Helper function to apply the same transformation to both members of a tuple
 --
--- > both Abs (1, 2) == (Abs 1, Abs 2s)
-both :: (a -> b) -> (a, a) -> (b, b)
-both f = bimap f f
+-- > mapBoth Abs (1, 2) == (Abs 1, Abs 2s)
+mapBoth :: (a -> b) -> (a, a) -> (b, b)
+mapBoth f = bimap f f
 
 -- | Render position in @(row, col)@ format to an Excel reference.
 --
@@ -133,7 +133,7 @@ singleCellRef' :: (Coord, Coord) -> CellRef
 singleCellRef' = CellRef . singleCellRefRaw'
 
 singleCellRefRaw :: (Int, Int) -> Text
-singleCellRefRaw = singleCellRefRaw' . both Rel
+singleCellRefRaw = singleCellRefRaw' . mapBoth Rel
 
 singleCellRefRaw' :: (Coord, Coord) -> Text
 singleCellRefRaw' (row, col) =
@@ -151,7 +151,7 @@ fromSingleCellRef' :: CellRef -> Maybe (Coord, Coord)
 fromSingleCellRef' = fromSingleCellRefRaw' . unCellRef
 
 fromSingleCellRefRaw :: Text -> Maybe (Int, Int)
-fromSingleCellRefRaw = fmap (both unCoord) . fromSingleCellRefRaw'
+fromSingleCellRefRaw = fmap (mapBoth unCoord) . fromSingleCellRefRaw'
 
 fromSingleCellRefRaw' :: Text -> Maybe (Coord, Coord)
 fromSingleCellRefRaw' t = do
@@ -209,7 +209,7 @@ mkForeignRange sheetName fr to =
 -- | reverse to 'mkRange'
 fromRange :: Range -> Maybe ((Int, Int), (Int, Int))
 fromRange r =
-  both (both unCoord) <$> fromRange' r
+  mapBoth (mapBoth unCoord) <$> fromRange' r
 
 -- | Converse function to 'mkRange\'' to handle possibly absolute coordinates.
 -- Ignores a potential foreign sheet prefix.

--- a/src/Codec/Xlsx/Types/DataValidation.hs
+++ b/src/Codec/Xlsx/Types/DataValidation.hs
@@ -7,6 +7,16 @@
 module Codec.Xlsx.Types.DataValidation
   ( ValidationExpression(..)
     , ValidationType(..)
+    , dvAllowBlank
+    , dvError
+    , dvErrorStyle
+    , dvErrorTitle
+    , dvPrompt
+    , dvPromptTitle
+    , dvShowDropDown
+    , dvShowErrorMessage
+    , dvShowInputMessage
+    , dvValidationType
     , ErrorStyle(..)
     , DataValidation(..)
     , ListOrRangeExpression(..)
@@ -33,7 +43,7 @@ import Data.ByteString (ByteString)
 import Data.Char (isSpace)
 import Data.Default
 import qualified Data.Map as M
-import Data.Maybe (catMaybes, isNothing, maybe, maybeToList)
+import Data.Maybe (catMaybes, maybeToList)
 import Data.Monoid ((<>))
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -225,9 +235,10 @@ readListFormulas (Formula f) = readQuotedList f <|> readUnquotedCellRange f
         = Just . ListExpression $ map (T.dropAround isSpace) $ T.splitOn "," t''
         | otherwise = Nothing
     readUnquotedCellRange t =
-      -- a single CellRef expression of a range (this is not validated beyond the absence of quotes)
-      let trimmed = T.dropAround isSpace t
-        in RangeExpression (CellRef trimmed) <$ guard (not (T.null trimmed))
+      -- a CellRef expression of a range (this is not validated beyond the absence of quotes)
+      -- note that the foreign sheet name can be 'single-quoted'
+      let stripped = T.dropAround isSpace t
+        in RangeExpression (CellRef stripped) <$ guard (not (T.null stripped))
   -- This parser expects a comma-separated list surrounded by quotation marks.
   -- Spaces around the quotation marks and commas are removed, but inner spaces
   -- are kept.

--- a/test/CommonTests.hs
+++ b/test/CommonTests.hs
@@ -52,10 +52,10 @@ tests =
        -- aren't inverses of each other in the range n E [60, 61[ for DateBase1900
        \b (n :: Pico) -> (n >= 60 && n < 61 && b == DateBase1900) || n == dateToNumber b (dateFromNumber b $ n)
     , testCase "building single CellRefs" $ do
-        singleCellRef' (both Rel (5, 25)) @?= CellRef "Y5"
+        singleCellRef' (mapBoth Rel (5, 25)) @?= CellRef "Y5"
         singleCellRef' (Rel 5, Abs 25) @?= CellRef "$Y5"
         singleCellRef' (Abs 5, Rel 25) @?= CellRef "Y$5"
-        singleCellRef' (both Abs (5, 25)) @?= CellRef "$Y$5"
+        singleCellRef' (mapBoth Abs (5, 25)) @?= CellRef "$Y$5"
         singleCellRef (5, 25) @?= CellRef "Y5"
     , testCase "parsing single CellRefs as abstract coordinates" $ do
         fromSingleCellRef (CellRef "Y5") @?= Just (5, 25)
@@ -63,17 +63,17 @@ tests =
         fromSingleCellRef (CellRef "Y$5") @?= Just (5, 25)
         fromSingleCellRef (CellRef "$Y$5") @?= Just (5, 25)
     , testCase "parsing single CellRefs as potentially absolute coordinates" $ do
-        fromSingleCellRef' (CellRef "Y5") @?= Just (both Rel (5, 25))
+        fromSingleCellRef' (CellRef "Y5") @?= Just (mapBoth Rel (5, 25))
         fromSingleCellRef' (CellRef "$Y5") @?= Just (Rel 5, Abs 25)
         fromSingleCellRef' (CellRef "Y$5") @?= Just (Abs 5, Rel 25)
-        fromSingleCellRef' (CellRef "$Y$5") @?= Just (both Abs (5, 25))
-        fromSingleCellRef' (CellRef "$Y$50") @?= Just (both Abs (50, 25))
+        fromSingleCellRef' (CellRef "$Y$5") @?= Just (mapBoth Abs (5, 25))
+        fromSingleCellRef' (CellRef "$Y$50") @?= Just (mapBoth Abs (50, 25))
         fromSingleCellRef' (CellRef "$Y$5$0") @?= Nothing
         fromSingleCellRef' (CellRef "Y5:Z10") @?= Nothing
     , testCase "building ranges" $ do
         mkRange (5, 25) (10, 26) @?= CellRef "Y5:Z10"
-        mkRange' (both Rel (5, 25)) (both Rel (10, 26)) @?= CellRef "Y5:Z10"
-        mkRange' (both Abs (5, 25)) (both Abs (10, 26)) @?= CellRef "$Y$5:$Z$10"
+        mkRange' (mapBoth Rel (5, 25)) (mapBoth Rel (10, 26)) @?= CellRef "Y5:Z10"
+        mkRange' (mapBoth Abs (5, 25)) (mapBoth Abs (10, 26)) @?= CellRef "$Y$5:$Z$10"
         mkRange' (Rel 5, Abs 25) (Abs 10, Rel 26) @?= CellRef "$Y5:Z$10"
         mkForeignRange "myWorksheet" (Rel 5, Abs 25) (Abs 10, Rel 26) @?= CellRef "'myWorksheet'!$Y5:Z$10"
         mkForeignRange "my sheet" (Rel 5, Abs 25) (Abs 10, Rel 26) @?= CellRef "'my sheet'!$Y5:Z$10"
@@ -82,12 +82,12 @@ tests =
         fromRange (CellRef "$Y$5:$Z$10") @?= Just ((5, 25), (10, 26))
         fromRange (CellRef "myWorksheet!$Y5:Z$10") @?= Just ((5, 25), (10, 26))
     , testCase "parsing ranges CellRefs as potentially absolute coordinates" $ do
-        fromRange' (CellRef "Y5:Z10") @?= Just (both (both Rel) ((5, 25), (10, 26)))
-        fromRange' (CellRef "$Y$5:$Z$10") @?= Just (both (both Abs) ((5, 25), (10, 26)))
+        fromRange' (CellRef "Y5:Z10") @?= Just (mapBoth (mapBoth Rel) ((5, 25), (10, 26)))
+        fromRange' (CellRef "$Y$5:$Z$10") @?= Just (mapBoth (mapBoth Abs) ((5, 25), (10, 26)))
         fromRange' (CellRef "myWorksheet!$Y5:Z$10") @?= Just ((Rel 5, Abs 25), (Abs 10, Rel 26))
         fromForeignRange (CellRef "myWorksheet!$Y5:Z$10") @?= Just ("myWorksheet", ((Rel 5, Abs 25), (Abs 10, Rel 26)))
-        fromForeignRange (CellRef "'myWorksheet'!Y5:Z10") @?= Just ("myWorksheet", both (both Rel) ((5, 25), (10, 26)))
-        fromForeignRange (CellRef "'my sheet'!Y5:Z10") @?= Just ("my sheet", both (both Rel) ((5, 25), (10, 26)))
+        fromForeignRange (CellRef "'myWorksheet'!Y5:Z10") @?= Just ("myWorksheet", mapBoth (mapBoth Rel) ((5, 25), (10, 26)))
+        fromForeignRange (CellRef "'my sheet'!Y5:Z10") @?= Just ("my sheet", mapBoth (mapBoth Rel) ((5, 25), (10, 26)))
         fromForeignRange (CellRef "$Y5:Z$10") @?= Nothing
     ]
 

--- a/test/CommonTests.hs
+++ b/test/CommonTests.hs
@@ -2,18 +2,36 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module CommonTests
   ( tests
   ) where
 
+import Control.Monad
+import qualified Control.Applicative as Alt
 import Data.Fixed (Pico, Fixed(..), E12)
 import Data.Time.Calendar (fromGregorian)
 import Data.Time.Clock (UTCTime(..))
+import Data.Text (Text)
+import Data.Word (Word8)
+import Data.Char (isPrint, chr)
+import qualified Data.Text as T
+import qualified Data.List as L
 import Test.Tasty.SmallCheck (testProperty)
-import Test.SmallCheck.Series
-       (Positive(..), Serial(..), newtypeCons, cons0, (\/))
+import Test.SmallCheck.Series as Series
+  ( Positive(..)
+  , NonEmpty(..)
+  , Serial(..)
+  , newtypeCons
+  , cons0
+  , cons1
+  , cons2
+  , generate
+  , (\/)
+  )
 import Test.Tasty (testGroup, TestTree)
 import Test.Tasty.HUnit (testCase, (@?=))
 
@@ -51,6 +69,43 @@ tests =
        -- Because excel treats 1900 as a leap year, dateToNumber and dateFromNumber
        -- aren't inverses of each other in the range n E [60, 61[ for DateBase1900
        \b (n :: Pico) -> (n >= 60 && n < 61 && b == DateBase1900) || n == dateToNumber b (dateFromNumber b $ n)
+
+    , testProperty "row2coord . coord2row = id" $ do
+        \(r :: Coord) -> r == row2coord (coord2row r)
+
+    , testProperty "col2coord . coord2col = id" $ do
+        \(c :: Coord) -> c == col2coord (coord2col c)
+
+    , testProperty "fromSingleCellRef' . singleCellRef' = pure" $ do
+        \(cellCoord :: CellCoord) -> pure cellCoord == fromSingleCellRef' (singleCellRef' cellCoord)
+
+    , testProperty "fromRange' . mkRange' = pure" $ do
+        \(range :: RangeCoord) -> pure range == fromRange' (uncurry mkRange' range)
+
+    , testProperty "fromForeignSingleCellRef . mkForeignSingleCellRef = pure" $ do
+        \(viewForeignCellParams -> params) ->
+            pure params == fromForeignSingleCellRef (uncurry mkForeignSingleCellRef params)
+
+    , testProperty "fromSingleCellRef' . mkForeignSingleCellRef = pure . snd" $ do
+        \(viewForeignCellParams -> (nStr, cellCoord)) ->
+            pure cellCoord == fromSingleCellRef' (mkForeignSingleCellRef nStr cellCoord)
+
+    , testProperty "fromForeignSingleCellRef . singleCellRef' = const empty" $ do
+        \(cellCoord :: CellCoord) ->
+            Alt.empty == fromForeignSingleCellRef (singleCellRef' cellCoord)
+
+    , testProperty "fromForeignRange . mkForeignRange = pure" $ do
+        \(viewForeignRangeParams -> params@(nStr, range@(start, end))) ->
+            pure params == fromForeignRange (mkForeignRange nStr start end)
+
+    , testProperty "fromRange' . mkForeignRange = pure . snd" $ do
+        \(viewForeignRangeParams -> (nStr, range@(start, end))) ->
+            pure range == fromRange' (mkForeignRange nStr start end)
+
+    , testProperty "fromForeignRange . mkRange' = const empty" $ do
+        \(range :: RangeCoord) ->
+            Alt.empty == fromForeignRange (uncurry mkRange' range)
+
     , testCase "building single CellRefs" $ do
         singleCellRef' (mapBoth Rel (5, 25)) @?= CellRef "Y5"
         singleCellRef' (Rel 5, Abs 25) @?= CellRef "$Y5"
@@ -96,3 +151,72 @@ instance Monad m => Serial m (Fixed E12) where
 
 instance Monad m  => Serial m DateBase where
   series = cons0 DateBase1900 \/ cons0 DateBase1904
+
+instance Monad m => Serial m Coord where
+  series = cons1 (Abs . getPositive) \/ cons1 (Rel . getPositive)
+
+-- | Allow defining an instance to generate valid foreign range params
+data MkForeignRangeRef = 
+  MkForeignRangeRef NameString RangeCoord
+  deriving (Show)
+
+viewForeignRangeParams :: MkForeignRangeRef -> (Text, RangeCoord)
+viewForeignRangeParams (MkForeignRangeRef nameStr range) = (nameString nameStr, range)
+
+instance Monad m => Serial m MkForeignRangeRef where
+  series = cons2 MkForeignRangeRef
+
+-- | Allow defining an instance to generate valid foreign cellref params
+data MkForeignCellRef =
+  MkForeignCellRef NameString CellCoord
+  deriving (Show)
+
+viewForeignCellParams :: MkForeignCellRef -> (Text, CellCoord)
+viewForeignCellParams (MkForeignCellRef nameStr coord) = (nameString nameStr, coord)
+
+instance Monad m => Serial m MkForeignCellRef where
+  series = cons2 MkForeignCellRef
+
+-- | Overload an instance for allowed sheet name chars
+newtype NameChar =
+  NameChar { _unNCh :: Char }
+  deriving (Show, Eq)
+
+-- | Instance for Char which broadens the pool to permitted ascii and some wchars
+-- as @Serial m Char@ is only @[ 'A' .. 'Z' ]@
+instance Monad m => Serial m NameChar where
+  series =
+    fmap NameChar $
+      let wChars = ['é', '€', '愛']
+          startSeq = "ab cd'" -- single quote is permitted as long as it's not 1st or last
+          authorizedAscii =
+            let asciiRange = L.map (chr . fromIntegral) [minBound @Word8 .. maxBound `div` 2]
+                forbiddenClass = "[]*:?/\\" :: String
+                isAuthorized c = isPrint c && not (c `L.elem` forbiddenClass)
+                isPlanned c = isAuthorized c && not (c `L.elem` startSeq)
+              in L.filter isAuthorized asciiRange
+        in generate $ \d -> take (d + 1) $ startSeq ++ wChars ++ authorizedAscii
+
+-- | Allow defining an instance to generate valid sheetnames (non-empty, valid char set, squote rule)
+newtype NameString =
+  NameString { _unNS :: Series.NonEmpty NameChar }
+  deriving (Show)
+
+nameString :: NameString -> Text
+nameString = T.pack . L.map _unNCh . getNonEmpty . _unNS
+
+instance Monad m => Serial m NameString where
+  series = fmap NameString $
+    series @m @(Series.NonEmpty NameChar) >>= \t -> t <$ guard (isOk t)
+        where
+          -- squote isn't permitted at the beginning and the end of a sheet's name
+          isOk (getNonEmpty -> s) = 
+            head s /= NameChar '\'' &&
+            last s /= NameChar '\''
+
+
+
+
+
+
+

--- a/test/CommonTests.hs
+++ b/test/CommonTests.hs
@@ -2,34 +2,21 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE ViewPatterns #-}
-{-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module CommonTests
   ( tests
   ) where
 
-import Control.Monad
-import qualified Control.Applicative as Alt
 import Data.Fixed (Pico, Fixed(..), E12)
 import Data.Time.Calendar (fromGregorian)
 import Data.Time.Clock (UTCTime(..))
-import Data.Text (Text)
-import Data.Word (Word8)
-import Data.Char (isPrint, chr)
-import qualified Data.Text as T
-import qualified Data.List as L
 import Test.Tasty.SmallCheck (testProperty)
 import Test.SmallCheck.Series as Series
   ( Positive(..)
-  , NonEmpty(..)
   , Serial(..)
   , newtypeCons
   , cons0
-  , cons1
-  , cons2
-  , generate
   , (\/)
   )
 import Test.Tasty (testGroup, TestTree)
@@ -37,13 +24,13 @@ import Test.Tasty.HUnit (testCase, (@?=))
 
 import Codec.Xlsx.Types.Common
 
+import qualified CommonTests.CellRefTests as CellRefTests
+
 tests :: TestTree
 tests =
   testGroup
     "Types.Common tests"
-    [ testProperty "col2int . int2col == id" $
-        \(Positive i) -> i == col2int (int2col i)
-    , testCase "date conversions" $ do
+    [ testCase "date conversions" $ do
         dateFromNumber DateBase1900 (- 2338.0) @?= read "1893-08-06 00:00:00 UTC"
         dateFromNumber DateBase1900 2.0 @?= read "1900-01-02 00:00:00 UTC"
         dateFromNumber DateBase1900 3687.0 @?= read "1910-02-03 00:00:00 UTC"
@@ -69,81 +56,7 @@ tests =
        -- Because excel treats 1900 as a leap year, dateToNumber and dateFromNumber
        -- aren't inverses of each other in the range n E [60, 61[ for DateBase1900
        \b (n :: Pico) -> (n >= 60 && n < 61 && b == DateBase1900) || n == dateToNumber b (dateFromNumber b $ n)
-
-    , testProperty "row2coord . coord2row = id" $ do
-        \(r :: Coord) -> r == row2coord (coord2row r)
-
-    , testProperty "col2coord . coord2col = id" $ do
-        \(c :: Coord) -> c == col2coord (coord2col c)
-
-    , testProperty "fromSingleCellRef' . singleCellRef' = pure" $ do
-        \(cellCoord :: CellCoord) -> pure cellCoord == fromSingleCellRef' (singleCellRef' cellCoord)
-
-    , testProperty "fromRange' . mkRange' = pure" $ do
-        \(range :: RangeCoord) -> pure range == fromRange' (uncurry mkRange' range)
-
-    , testProperty "fromForeignSingleCellRef . mkForeignSingleCellRef = pure" $ do
-        \(viewForeignCellParams -> params) ->
-            pure params == fromForeignSingleCellRef (uncurry mkForeignSingleCellRef params)
-
-    , testProperty "fromSingleCellRef' . mkForeignSingleCellRef = pure . snd" $ do
-        \(viewForeignCellParams -> (nStr, cellCoord)) ->
-            pure cellCoord == fromSingleCellRef' (mkForeignSingleCellRef nStr cellCoord)
-
-    , testProperty "fromForeignSingleCellRef . singleCellRef' = const empty" $ do
-        \(cellCoord :: CellCoord) ->
-            Alt.empty == fromForeignSingleCellRef (singleCellRef' cellCoord)
-
-    , testProperty "fromForeignRange . mkForeignRange = pure" $ do
-        \(viewForeignRangeParams -> params@(nStr, range@(start, end))) ->
-            pure params == fromForeignRange (mkForeignRange nStr start end)
-
-    , testProperty "fromRange' . mkForeignRange = pure . snd" $ do
-        \(viewForeignRangeParams -> (nStr, range@(start, end))) ->
-            pure range == fromRange' (mkForeignRange nStr start end)
-
-    , testProperty "fromForeignRange . mkRange' = const empty" $ do
-        \(range :: RangeCoord) ->
-            Alt.empty == fromForeignRange (uncurry mkRange' range)
-
-    , testCase "building single CellRefs" $ do
-        singleCellRef' (mapBoth Rel (5, 25)) @?= CellRef "Y5"
-        singleCellRef' (Rel 5, Abs 25) @?= CellRef "$Y5"
-        singleCellRef' (Abs 5, Rel 25) @?= CellRef "Y$5"
-        singleCellRef' (mapBoth Abs (5, 25)) @?= CellRef "$Y$5"
-        singleCellRef (5, 25) @?= CellRef "Y5"
-    , testCase "parsing single CellRefs as abstract coordinates" $ do
-        fromSingleCellRef (CellRef "Y5") @?= Just (5, 25)
-        fromSingleCellRef (CellRef "$Y5") @?= Just (5, 25)
-        fromSingleCellRef (CellRef "Y$5") @?= Just (5, 25)
-        fromSingleCellRef (CellRef "$Y$5") @?= Just (5, 25)
-    , testCase "parsing single CellRefs as potentially absolute coordinates" $ do
-        fromSingleCellRef' (CellRef "Y5") @?= Just (mapBoth Rel (5, 25))
-        fromSingleCellRef' (CellRef "$Y5") @?= Just (Rel 5, Abs 25)
-        fromSingleCellRef' (CellRef "Y$5") @?= Just (Abs 5, Rel 25)
-        fromSingleCellRef' (CellRef "$Y$5") @?= Just (mapBoth Abs (5, 25))
-        fromSingleCellRef' (CellRef "$Y$50") @?= Just (mapBoth Abs (50, 25))
-        fromSingleCellRef' (CellRef "$Y$5$0") @?= Nothing
-        fromSingleCellRef' (CellRef "Y5:Z10") @?= Nothing
-    , testCase "building ranges" $ do
-        mkRange (5, 25) (10, 26) @?= CellRef "Y5:Z10"
-        mkRange' (mapBoth Rel (5, 25)) (mapBoth Rel (10, 26)) @?= CellRef "Y5:Z10"
-        mkRange' (mapBoth Abs (5, 25)) (mapBoth Abs (10, 26)) @?= CellRef "$Y$5:$Z$10"
-        mkRange' (Rel 5, Abs 25) (Abs 10, Rel 26) @?= CellRef "$Y5:Z$10"
-        mkForeignRange "myWorksheet" (Rel 5, Abs 25) (Abs 10, Rel 26) @?= CellRef "'myWorksheet'!$Y5:Z$10"
-        mkForeignRange "my sheet" (Rel 5, Abs 25) (Abs 10, Rel 26) @?= CellRef "'my sheet'!$Y5:Z$10"
-    , testCase "parsing ranges CellRefs as abstract coordinates" $ do
-        fromRange (CellRef "Y5:Z10") @?= Just ((5, 25), (10, 26))
-        fromRange (CellRef "$Y$5:$Z$10") @?= Just ((5, 25), (10, 26))
-        fromRange (CellRef "myWorksheet!$Y5:Z$10") @?= Just ((5, 25), (10, 26))
-    , testCase "parsing ranges CellRefs as potentially absolute coordinates" $ do
-        fromRange' (CellRef "Y5:Z10") @?= Just (mapBoth (mapBoth Rel) ((5, 25), (10, 26)))
-        fromRange' (CellRef "$Y$5:$Z$10") @?= Just (mapBoth (mapBoth Abs) ((5, 25), (10, 26)))
-        fromRange' (CellRef "myWorksheet!$Y5:Z$10") @?= Just ((Rel 5, Abs 25), (Abs 10, Rel 26))
-        fromForeignRange (CellRef "myWorksheet!$Y5:Z$10") @?= Just ("myWorksheet", ((Rel 5, Abs 25), (Abs 10, Rel 26)))
-        fromForeignRange (CellRef "'myWorksheet'!Y5:Z10") @?= Just ("myWorksheet", mapBoth (mapBoth Rel) ((5, 25), (10, 26)))
-        fromForeignRange (CellRef "'my sheet'!Y5:Z10") @?= Just ("my sheet", mapBoth (mapBoth Rel) ((5, 25), (10, 26)))
-        fromForeignRange (CellRef "$Y5:Z$10") @?= Nothing
+     , CellRefTests.tests
     ]
 
 instance Monad m => Serial m (Fixed E12) where
@@ -151,72 +64,3 @@ instance Monad m => Serial m (Fixed E12) where
 
 instance Monad m  => Serial m DateBase where
   series = cons0 DateBase1900 \/ cons0 DateBase1904
-
-instance Monad m => Serial m Coord where
-  series = cons1 (Abs . getPositive) \/ cons1 (Rel . getPositive)
-
--- | Allow defining an instance to generate valid foreign range params
-data MkForeignRangeRef = 
-  MkForeignRangeRef NameString RangeCoord
-  deriving (Show)
-
-viewForeignRangeParams :: MkForeignRangeRef -> (Text, RangeCoord)
-viewForeignRangeParams (MkForeignRangeRef nameStr range) = (nameString nameStr, range)
-
-instance Monad m => Serial m MkForeignRangeRef where
-  series = cons2 MkForeignRangeRef
-
--- | Allow defining an instance to generate valid foreign cellref params
-data MkForeignCellRef =
-  MkForeignCellRef NameString CellCoord
-  deriving (Show)
-
-viewForeignCellParams :: MkForeignCellRef -> (Text, CellCoord)
-viewForeignCellParams (MkForeignCellRef nameStr coord) = (nameString nameStr, coord)
-
-instance Monad m => Serial m MkForeignCellRef where
-  series = cons2 MkForeignCellRef
-
--- | Overload an instance for allowed sheet name chars
-newtype NameChar =
-  NameChar { _unNCh :: Char }
-  deriving (Show, Eq)
-
--- | Instance for Char which broadens the pool to permitted ascii and some wchars
--- as @Serial m Char@ is only @[ 'A' .. 'Z' ]@
-instance Monad m => Serial m NameChar where
-  series =
-    fmap NameChar $
-      let wChars = ['é', '€', '愛']
-          startSeq = "ab cd'" -- single quote is permitted as long as it's not 1st or last
-          authorizedAscii =
-            let asciiRange = L.map (chr . fromIntegral) [minBound @Word8 .. maxBound `div` 2]
-                forbiddenClass = "[]*:?/\\" :: String
-                isAuthorized c = isPrint c && not (c `L.elem` forbiddenClass)
-                isPlanned c = isAuthorized c && not (c `L.elem` startSeq)
-              in L.filter isAuthorized asciiRange
-        in generate $ \d -> take (d + 1) $ startSeq ++ wChars ++ authorizedAscii
-
--- | Allow defining an instance to generate valid sheetnames (non-empty, valid char set, squote rule)
-newtype NameString =
-  NameString { _unNS :: Series.NonEmpty NameChar }
-  deriving (Show)
-
-nameString :: NameString -> Text
-nameString = T.pack . L.map _unNCh . getNonEmpty . _unNS
-
-instance Monad m => Serial m NameString where
-  series = fmap NameString $
-    series @m @(Series.NonEmpty NameChar) >>= \t -> t <$ guard (isOk t)
-        where
-          -- squote isn't permitted at the beginning and the end of a sheet's name
-          isOk (getNonEmpty -> s) = 
-            head s /= NameChar '\'' &&
-            last s /= NameChar '\''
-
-
-
-
-
-
-

--- a/test/CommonTests/CellRefTests.hs
+++ b/test/CommonTests/CellRefTests.hs
@@ -1,0 +1,174 @@
+
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE ViewPatterns          #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module CommonTests.CellRefTests
+  ( tests
+  ) where
+
+import qualified Control.Applicative as Alt
+import Control.Monad
+import Data.Char (chr, isPrint)
+import qualified Data.List as L
+import Data.Text (Text)
+import qualified Data.Text as T
+import Data.Word (Word8)
+import Test.SmallCheck.Series as Series (NonEmpty (..), Positive (..),
+                                         Serial (..), cons1, cons2, generate,
+                                         (\/))
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (testCase, (@?=))
+import Test.Tasty.SmallCheck (testProperty)
+
+import Codec.Xlsx.Types.Common
+
+tests :: TestTree
+tests =
+  testGroup
+    "Types.Common CellRef tests"
+  [ testProperty "col2int . int2col == id" $
+        \(Positive i) -> i == col2int (int2col i)
+
+    , testProperty "row2coord . coord2row = id" $
+        \(r :: Coord) -> r == row2coord (coord2row r)
+
+    , testProperty "col2coord . coord2col = id" $
+        \(c :: Coord) -> c == col2coord (coord2col c)
+
+    , testProperty "fromSingleCellRef' . singleCellRef' = pure" $
+        \(cellCoord :: CellCoord) -> pure cellCoord == fromSingleCellRef' (singleCellRef' cellCoord)
+
+    , testProperty "fromRange' . mkRange' = pure" $
+        \(range :: RangeCoord) -> pure range == fromRange' (uncurry mkRange' range)
+
+    , testProperty "fromForeignSingleCellRef . mkForeignSingleCellRef = pure" $
+        \(viewForeignCellParams -> params) ->
+            pure params == fromForeignSingleCellRef (uncurry mkForeignSingleCellRef params)
+
+    , testProperty "fromSingleCellRef' . mkForeignSingleCellRef = pure . snd" $
+        \(viewForeignCellParams -> (nStr, cellCoord)) ->
+            pure cellCoord == fromSingleCellRef' (mkForeignSingleCellRef nStr cellCoord)
+
+    , testProperty "fromForeignSingleCellRef . singleCellRef' = const empty" $
+        \(cellCoord :: CellCoord) ->
+            Alt.empty == fromForeignSingleCellRef (singleCellRef' cellCoord)
+
+    , testProperty "fromForeignRange . mkForeignRange = pure" $
+        \(viewForeignRangeParams -> params@(nStr, (start, end))) ->
+            pure params == fromForeignRange (mkForeignRange nStr start end)
+
+    , testProperty "fromRange' . mkForeignRange = pure . snd" $
+        \(viewForeignRangeParams -> (nStr, range@(start, end))) ->
+            pure range == fromRange' (mkForeignRange nStr start end)
+
+    , testProperty "fromForeignRange . mkRange' = const empty" $
+        \(range :: RangeCoord) ->
+            Alt.empty == fromForeignRange (uncurry mkRange' range)
+
+    , testCase "building single CellRefs" $ do
+        singleCellRef' (mapBoth Rel (5, 25)) @?= CellRef "Y5"
+        singleCellRef' (Rel 5, Abs 25) @?= CellRef "$Y5"
+        singleCellRef' (Abs 5, Rel 25) @?= CellRef "Y$5"
+        singleCellRef' (mapBoth Abs (5, 25)) @?= CellRef "$Y$5"
+        singleCellRef (5, 25) @?= CellRef "Y5"
+    , testCase "parsing single CellRefs as abstract coordinates" $ do
+        fromSingleCellRef (CellRef "Y5") @?= Just (5, 25)
+        fromSingleCellRef (CellRef "$Y5") @?= Just (5, 25)
+        fromSingleCellRef (CellRef "Y$5") @?= Just (5, 25)
+        fromSingleCellRef (CellRef "$Y$5") @?= Just (5, 25)
+    , testCase "parsing single CellRefs as potentially absolute coordinates" $ do
+        fromSingleCellRef' (CellRef "Y5") @?= Just (mapBoth Rel (5, 25))
+        fromSingleCellRef' (CellRef "$Y5") @?= Just (Rel 5, Abs 25)
+        fromSingleCellRef' (CellRef "Y$5") @?= Just (Abs 5, Rel 25)
+        fromSingleCellRef' (CellRef "$Y$5") @?= Just (mapBoth Abs (5, 25))
+        fromSingleCellRef' (CellRef "$Y$50") @?= Just (mapBoth Abs (50, 25))
+        fromSingleCellRef' (CellRef "$Y$5$0") @?= Nothing
+        fromSingleCellRef' (CellRef "Y5:Z10") @?= Nothing
+    , testCase "building ranges" $ do
+        mkRange (5, 25) (10, 26) @?= CellRef "Y5:Z10"
+        mkRange' (mapBoth Rel (5, 25)) (mapBoth Rel (10, 26)) @?= CellRef "Y5:Z10"
+        mkRange' (mapBoth Abs (5, 25)) (mapBoth Abs (10, 26)) @?= CellRef "$Y$5:$Z$10"
+        mkRange' (Rel 5, Abs 25) (Abs 10, Rel 26) @?= CellRef "$Y5:Z$10"
+        mkForeignRange "myWorksheet" (Rel 5, Abs 25) (Abs 10, Rel 26) @?= CellRef "'myWorksheet'!$Y5:Z$10"
+        mkForeignRange "my sheet" (Rel 5, Abs 25) (Abs 10, Rel 26) @?= CellRef "'my sheet'!$Y5:Z$10"
+    , testCase "parsing ranges CellRefs as abstract coordinates" $ do
+        fromRange (CellRef "Y5:Z10") @?= Just ((5, 25), (10, 26))
+        fromRange (CellRef "$Y$5:$Z$10") @?= Just ((5, 25), (10, 26))
+        fromRange (CellRef "myWorksheet!$Y5:Z$10") @?= Just ((5, 25), (10, 26))
+    , testCase "parsing ranges CellRefs as potentially absolute coordinates" $ do
+        fromRange' (CellRef "Y5:Z10") @?= Just (mapBoth (mapBoth Rel) ((5, 25), (10, 26)))
+        fromRange' (CellRef "$Y$5:$Z$10") @?= Just (mapBoth (mapBoth Abs) ((5, 25), (10, 26)))
+        fromRange' (CellRef "myWorksheet!$Y5:Z$10") @?= Just ((Rel 5, Abs 25), (Abs 10, Rel 26))
+        fromForeignRange (CellRef "myWorksheet!$Y5:Z$10") @?= Just ("myWorksheet", ((Rel 5, Abs 25), (Abs 10, Rel 26)))
+        fromForeignRange (CellRef "'myWorksheet'!Y5:Z10") @?= Just ("myWorksheet", mapBoth (mapBoth Rel) ((5, 25), (10, 26)))
+        fromForeignRange (CellRef "'my sheet'!Y5:Z10") @?= Just ("my sheet", mapBoth (mapBoth Rel) ((5, 25), (10, 26)))
+        fromForeignRange (CellRef "$Y5:Z$10") @?= Nothing
+  ]
+
+
+instance Monad m => Serial m Coord where
+  series = cons1 (Abs . getPositive) \/ cons1 (Rel . getPositive)
+
+-- | Allow defining an instance to generate valid foreign range params
+data MkForeignRangeRef =
+  MkForeignRangeRef NameString RangeCoord
+  deriving (Show)
+
+viewForeignRangeParams :: MkForeignRangeRef -> (Text, RangeCoord)
+viewForeignRangeParams (MkForeignRangeRef nameStr range) = (nameString nameStr, range)
+
+instance Monad m => Serial m MkForeignRangeRef where
+  series = cons2 MkForeignRangeRef
+
+-- | Allow defining an instance to generate valid foreign cellref params
+data MkForeignCellRef =
+  MkForeignCellRef NameString CellCoord
+  deriving (Show)
+
+viewForeignCellParams :: MkForeignCellRef -> (Text, CellCoord)
+viewForeignCellParams (MkForeignCellRef nameStr coord) = (nameString nameStr, coord)
+
+instance Monad m => Serial m MkForeignCellRef where
+  series = cons2 MkForeignCellRef
+
+-- | Overload an instance for allowed sheet name chars
+newtype NameChar =
+  NameChar { _unNCh :: Char }
+  deriving (Show, Eq)
+
+-- | Instance for Char which broadens the pool to permitted ascii and some wchars
+-- as @Serial m Char@ is only @[ 'A' .. 'Z' ]@
+instance Monad m => Serial m NameChar where
+  series =
+    fmap NameChar $
+      let wChars = ['é', '€', '愛']
+          startSeq = "ab cd'" -- single quote is permitted as long as it's not 1st or last
+          authorizedAscii =
+            let asciiRange = L.map (chr . fromIntegral) [minBound @Word8 .. maxBound `div` 2]
+                forbiddenClass = "[]*:?/\\" :: String
+                isAuthorized c = isPrint c && not (c `L.elem` forbiddenClass)
+                isPlanned c = isAuthorized c && not (c `L.elem` startSeq)
+              in L.filter isPlanned asciiRange
+        in generate $ \d -> take (d + 1) $ startSeq ++ wChars ++ authorizedAscii
+
+-- | Allow defining an instance to generate valid sheetnames (non-empty, valid char set, squote rule)
+newtype NameString =
+  NameString { _unNS :: Series.NonEmpty NameChar }
+  deriving (Show)
+
+nameString :: NameString -> Text
+nameString = T.pack . L.map _unNCh . getNonEmpty . _unNS
+
+instance Monad m => Serial m NameString where
+  series = fmap NameString $
+    series @m @(Series.NonEmpty NameChar) >>= \t -> t <$ guard (isOk t)
+        where
+          -- squote isn't permitted at the beginning and the end of a sheet's name
+          isOk (getNonEmpty -> s) =
+            head s /= NameChar '\'' &&
+            last s /= NameChar '\''

--- a/xlsx.cabal
+++ b/xlsx.cabal
@@ -148,6 +148,7 @@ test-suite data-test
   other-modules: AutoFilterTests
                , Common
                , CommonTests
+               , CommonTests.CellRefTests
                , CondFmtTests
                , Diff
                , DrawingTests


### PR DESCRIPTION
Closes https://github.com/qrilka/xlsx/issues/156

* add cell range support  <dataValidation type="list">
* add absolute coordinate support

Basically when I needed to implement flavours of `mkRange` `mkSingleCellRef` and matching `from*` functions, I've kept historical behaviour and types and instead wrote "prime" variants `mkRange'` etc