### PR TITLE
feat: add support for ST_SheetState (visibility)

### DIFF
--- a/src/Codec/Xlsx/Formatted.hs
+++ b/src/Codec/Xlsx/Formatted.hs
@@ -245,6 +245,7 @@ formatted cs styleSheet =
         , formattedMerges     = reverse (finalSt ^. formattingMerges)
         }
 
+-- | Build an 'Xlsx', render provided cells as per the 'StyleSheet'.
 formatWorkbook :: [(Text, Map (Int, Int) FormattedCell)] -> StyleSheet -> Xlsx
 formatWorkbook nfcss initStyle = extract go
   where

--- a/src/Codec/Xlsx/Writer.hs
+++ b/src/Codec/Xlsx/Writer.hs
@@ -89,7 +89,7 @@ fromXlsx pt xlsx =
                     (customPropsXml (CustomProperties customProps)) ],
                   [ ("custom-properties", "docProps/custom.xml") ])
     workbookFiles = bookFiles xlsx
-    sheetNames = xlsx ^. xlSheets . to (map fst)
+    sheetNames = xlsx ^. xlSheets & mapped %~ fst
 
 singleSheetFiles :: Int
                  -> Cells
@@ -489,7 +489,7 @@ bookFiles :: Xlsx -> [FileData]
 bookFiles xlsx = runST $ do
   ref <- newSTRef 1
   ssRId <- nextRefId ref
-  let sheets = xlsx ^. xlSheets . to (map snd)
+  let sheets = xlsx ^. xlSheets & mapped %~ snd
       shared = sstConstruct sheets
       sharedStrings =
         (ssRId, FileData "xl/sharedStrings.xml" (smlCT "sharedStrings") "sharedStrings" $
@@ -514,7 +514,10 @@ bookFiles xlsx = runST $ do
     (sheetFile, others) <- singleSheetFiles i cells pvTables sheet tblIdRef
     return ((rId, sheetFile), others)
   let sheetFiles = map fst allSheetFiles
-      sheetNameByRId = zip (map fst sheetFiles) (xlsx ^. xlSheets . to (map fst))
+      sheetAttrsByRId =
+        zipWith (\(rId, _) (name, sheet) -> (rId, name, sheet ^. wsState))
+          sheetFiles
+          (xlsx ^. xlSheets)
       sheetOthers = concatMap snd allSheetFiles
   cacheRefFDsById <- forM cacheIdFiles $ \(cacheId, fd) -> do
       refId <- nextRefId ref
@@ -522,7 +525,7 @@ bookFiles xlsx = runST $ do
   let cacheRefsById = [ (cId, rId) | (cId, (rId, _)) <- cacheRefFDsById ]
       cacheRefs = map snd cacheRefFDsById
       bookFile = FileData "xl/workbook.xml" (smlCT "sheet.main") "officeDocument" $
-                 bookXml sheetNameByRId (xlsx ^. xlDefinedNames) cacheRefsById (xlsx ^. xlDateBase)
+                 bookXml sheetAttrsByRId (xlsx ^. xlDefinedNames) cacheRefsById (xlsx ^. xlDateBase)
       rels = FileData "xl/_rels/workbook.xml.rels"
              "application/vnd.openxmlformats-package.relationships+xml"
              "relationships" relsXml
@@ -533,12 +536,12 @@ bookFiles xlsx = runST $ do
       otherFiles = concat [rels:(map snd referenced), pivotOtherFiles, sheetOthers]
   return $ bookFile:otherFiles
 
-bookXml :: [(RefId, Text)]
+bookXml :: [(RefId, Text, SheetState)]
         -> DefinedNames
         -> [(CacheId, RefId)]
         -> DateBase
         -> L.ByteString
-bookXml rIdNames (DefinedNames names) cacheIdRefs dateBase =
+bookXml rIdAttrs (DefinedNames names) cacheIdRefs dateBase =
   renderLBS def {rsNamespaces = nss} $ Document (Prologue [] Nothing []) root []
   where
     nss = [ ("r", "http://schemas.openxmlformats.org/officeDocument/2006/relationships") ]
@@ -557,8 +560,8 @@ bookXml rIdNames (DefinedNames names) cacheIdRefs dateBase =
             "sheets"
             [ leafElement
               "sheet"
-              ["name" .= name, "sheetId" .= i, (odr "id") .= rId]
-            | (i, (rId, name)) <- zip [(1 :: Int) ..] rIdNames
+              ["name" .= name, "sheetId" .= i, "state" .= state, (odr "id") .= rId]
+            | (i, (rId, name, state)) <- zip [(1 :: Int) ..] rIdAttrs
             ]
           , elementListSimple
             "definedNames"

--- a/test/Common.hs
+++ b/test/Common.hs
@@ -1,3 +1,7 @@
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
 module Common
   ( parseBS
   , cursorFromElement
@@ -7,10 +11,15 @@ import Text.XML
 import Text.XML.Cursor
 
 import Codec.Xlsx.Parser.Internal
+import Codec.Xlsx.Types (SheetState (..))
 import Codec.Xlsx.Writer.Internal
+
+import Test.SmallCheck.Series (Serial)
 
 parseBS :: FromCursor a => ByteString -> [a]
 parseBS = fromCursor . fromDocument . parseLBS_ def
 
 cursorFromElement :: Element -> Cursor
 cursorFromElement = fromNode . NodeElement . addNS mainNamespace Nothing
+
+instance Monad m  => Serial m SheetState

--- a/test/TestXlsx.hs
+++ b/test/TestXlsx.hs
@@ -7,25 +7,18 @@
 module TestXlsx where
 
 #ifdef USE_MICROLENS
-import           Lens.Micro.Platform
+import Lens.Micro.Platform
 #else
 import Control.Lens
 #endif
 import Control.Monad.State.Lazy
 import Data.ByteString.Lazy (ByteString)
-import qualified Data.ByteString.Lazy as LB
 import Data.Map (Map)
 import qualified Data.Map as M
-import Data.Text (Text)
 import Data.Time.Clock.POSIX (POSIXTime)
 import qualified Data.Vector as V
 import Text.RawString.QQ
 import Text.XML
-
-import Test.Tasty (defaultMain, testGroup)
-import Test.Tasty.HUnit (testCase)
-
-import Test.Tasty.HUnit ((@=?))
 
 import Codec.Xlsx
 import Codec.Xlsx.Formatted
@@ -35,11 +28,6 @@ import Codec.Xlsx.Types.Internal.CustomProperties
        as CustomProperties
 import Codec.Xlsx.Types.Internal.SharedStringTable
 
-import AutoFilterTests
-import Common
-import CommonTests
-import CondFmtTests
-import Diff
 import PivotTableTests
 import DrawingTests
 
@@ -52,10 +40,12 @@ testXlsx = Xlsx sheets minimalStyles definedNames customProperties DateBase1904
       , ("with pivot table", pvSheet)
       , ("cellrange DV source", foreignDvSourceSheet) -- "foreign" sheet holding validation data
       , ("cellrange DV test", foreignDvTestSheet) -- applies validation using foreign cell ranges
+      , ("hidden sheet", def & wsState .~ Hidden & cellValueAt (1,1) ?~ CellText "I'm hidden!")
+      , ("VERY hidden sheet", def & wsState .~ VeryHidden & cellValueAt (1,1) ?~ CellText "I'm VERY hidden!!")
       ]
     sheet1 = Worksheet cols rowProps testCellMap1 drawing ranges
       sheetViews pageSetup cFormatting validations [] (Just autoFilter)
-      tables (Just protection) sharedFormulas
+      tables (Just protection) sharedFormulas def
     sharedFormulas =
       M.fromList
         [ (SharedFormulaIndex 0, SharedFormulaOptions (CellRef "A5:C5") (Formula "A4"))
@@ -461,17 +451,15 @@ testFormatWorkbookResult :: Xlsx
 testFormatWorkbookResult = def & xlSheets .~ sheets
                                & xlStyles .~ renderStyleSheet style
   where
-    testCellMap1 = M.fromList [((1, 1), Cell { _cellStyle   = Nothing
-                                             , _cellValue   = Just (CellText "text at A1 Sheet1")
-                                             , _cellComment = Nothing
-                                             , _cellFormula = Nothing })]
-    testCellMap2 = M.fromList [((2, 3), Cell { _cellStyle   = Just 1
-                                             , _cellValue   = Just (CellDouble 1.23456)
-                                             , _cellComment = Nothing
-                                             , _cellFormula = Nothing })]
-    sheets = [ ("Sheet1", def & wsCells .~ testCellMap1)
-             , ("Sheet2", def & wsCells .~ testCellMap2)
-             ]
+    cellMap1 = M.fromList [((1, 1), Cell { _cellStyle   = Nothing
+                                              , _cellValue   = Just (CellText "text at A1 Sheet1")
+                                              , _cellComment = Nothing
+                                              , _cellFormula = Nothing })]
+    cellMap2 = M.fromList [((2, 3), Cell { _cellStyle   = Just 1
+                                              , _cellValue   = Just (CellDouble 1.23456)
+                                              , _cellComment = Nothing
+                                              , _cellFormula = Nothing })]
+    sheets = [ ("Sheet1", def & wsCells .~ cellMap1) , ("Sheet2", def & wsCells .~ cellMap2) ]
     style = minimalStyleSheet & styleSheetNumFmts .~ M.fromList [(164, "DD.MM.YYYY")]
                               & styleSheetCellXfs .~ [cellXf1, cellXf2]
     cellXf1 = def


### PR DESCRIPTION
Allow parsing and managing the visibility of sheets.

I've tried to be as conservative as possible but perhaps `xlSheets` would benefit from having it's own ADT rather than expanding sheets tuple?

**edit** more details:

Although it feels clunkier to extend `_xlSheets` tuples to include the ST_State, it's a sheet attribute on the same level as the name.

I first though about adding a `Worksheet` field for the state (and perhaps that would've been better?) but reading how <code>&#60;sheet ... &#62;</code> attributes are handled I've decided to track it at the same level as sheet `name`s

Tell me how you feel about it :) it would simplify `_xlSheets` lenses a great deal to rather have it as `_wsState` or something.