### PR TITLE
Parse comment visibility rather than setting it to True when parsing.

### DIFF
--- a/test/StreamTests.hs
+++ b/test/StreamTests.hs
@@ -48,6 +48,9 @@ import Data.Set (Set)
 import Text.Printf
 import Data.Conduit
 
+tshow :: Show a => a -> Text
+tshow = Text.pack . show
+
 toBs :: Xlsx -> BS.ByteString
 toBs = LB.toStrict . fromXlsx testTime
 
@@ -138,10 +141,6 @@ simpleWorkbookRow :: Xlsx
 simpleWorkbookRow = def & atSheet "Sheet1" ?~ sheet
   where
     sheet = toWs [((1,1), a1), ((2,1), cellValue ?~ CellText "text at A2 Sheet1" $ def)]
-
-
-tshow :: Show a => a -> Text
-tshow = Text.pack . show
 
 toWs :: [((Int,Int), Cell)] -> Worksheet
 toWs x = set wsCells (M.fromList x) def

--- a/test/TestXlsx.hs
+++ b/test/TestXlsx.hs
@@ -257,7 +257,7 @@ testSharedStringTableWithEmpty =
 
 testCommentTable :: CommentTable
 testCommentTable = CommentTable $ M.fromList
-    [ (CellRef "D4", Comment (XlsxRichText rich) "Bob" True)
+    [ (CellRef "D4", Comment (XlsxRichText rich) "Bob" False)
     , (CellRef "A2", Comment (XlsxText "Some comment here") "CBR" True) ]
   where
     rich = [ RichTextRun
@@ -325,7 +325,7 @@ testComments = [r|
     <author>CBR</author>
   </authors>
   <commentList>
-    <comment ref="D4" authorId="0">
+    <comment ref="D4" authorId="0" visible="False">
       <text>
         <r>
           <rPr>
@@ -343,7 +343,7 @@ testComments = [r|
         </r>
       </text>
     </comment>
-    <comment ref="A2" authorId="1">
+    <comment ref="A2" authorId="1" visible="True">
       <text><t>Some comment here</t></text>
     </comment>
   </commentList>


### PR DESCRIPTION
The parseComment function parses everything except for visibility, and then ends with `return (ref, Comment txt author True)`. This PR changes the function so that it also parses visibility and then ends with `return (ref, Comment txt author visibility)`

Seems like this got through the previous test because there was only a case for when comments are visible, but not for when comments are invisible. So this PR also makes 1 of the 2 visible comments in the test invisible. Side note: the r function doesn't support variable interpolation, so "True" and "False" have been hardcoded into testComments. Therefore, there is an assumption that 'tshow False' and 'tshow True' will always evaluate to "False" and "True" respectively, although this seems like a relatively safe assumption.