### PR TITLE
Import `Control.Monad`

### DIFF
--- a/test/StreamTests.hs
+++ b/test/StreamTests.hs
@@ -40,6 +40,7 @@ import Test.Tasty.HUnit (testCase)
 import TestXlsx
 import qualified Codec.Xlsx.Writer.Stream as SW
 import qualified Codec.Xlsx.Writer.Internal.Stream as SW
+import Control.Monad (void)
 import Control.Monad.State.Lazy
 import Test.Tasty.SmallCheck
 import Test.SmallCheck.Series.Instances ()


### PR DESCRIPTION
mtl-2.3 removed this reexport. Not sure why this wasn't caught in https://github.com/qrilka/xlsx/pull/167