### PR TITLE
Replace Double in CellValue by Scientific

### DIFF
--- a/src/Codec/Xlsx/Parser.hs
+++ b/src/Codec/Xlsx/Parser.hs
@@ -336,7 +336,7 @@ extractSheetFast ar sst contentTypes caches wf = do
               Nothing -> throwError "bad shared string index"
           "inlineStr" -> mapM (fmap xlsxTextToCellValue . fromXenoNode) isNode
           "str" -> fmap CellText <$> vConverted
-          "n" -> fmap CellDouble <$> vConverted
+          "n" -> fmap CellDecimal <$> vConverted
           "b" -> fmap CellBool <$> vConverted
           "e" -> fmap CellError <$> vConverted
           unexpected ->
@@ -514,7 +514,7 @@ extractCellValue sst t cur
   | t == "inlineStr" =
     cur $/ element (n_ "is") >=> fmap xlsxTextToCellValue . fromCursor
   | t == "str" = CellText <$> vConverted "string"
-  | t == "n" = CellDouble <$> vConverted "double"
+  | t == "n" = CellDecimal <$> vConverted "scientific"
   | t == "b" = CellBool <$> vConverted "boolean"
   | t == "e" = CellError <$> vConverted "error"
   | otherwise = fail "bad cell value"

--- a/src/Codec/Xlsx/Parser/Internal.hs
+++ b/src/Codec/Xlsx/Parser/Internal.hs
@@ -33,6 +33,7 @@ import Data.Maybe
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Read as T
+import Data.Scientific (Scientific)
 import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 import Text.XML
@@ -66,6 +67,9 @@ instance FromAttrVal Integer where
     fromAttrVal = T.signed T.decimal
 
 instance FromAttrVal Double where
+    fromAttrVal = T.rational
+
+instance FromAttrVal Scientific where
     fromAttrVal = T.rational
 
 instance FromAttrVal Bool where

--- a/src/Codec/Xlsx/Parser/Internal/Fast.hs
+++ b/src/Codec/Xlsx/Parser/Internal/Fast.hs
@@ -43,6 +43,7 @@ import qualified Data.ByteString.Unsafe as SU
 import Data.Char (chr)
 import Data.Maybe
 import Data.Monoid ((<>))
+import Data.Scientific (Scientific)
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
@@ -228,6 +229,10 @@ instance FromAttrBs Int where
   fromAttrBs = first T.pack . eitherDecimal . T.decodeLatin1
 
 instance FromAttrBs Double where
+  -- as for rationals
+  fromAttrBs = first T.pack . eitherRational . T.decodeLatin1
+
+instance FromAttrBs Scientific where
   -- as for rationals
   fromAttrBs = first T.pack . eitherRational . T.decodeLatin1
 

--- a/src/Codec/Xlsx/Parser/Internal/PivotTable.hs
+++ b/src/Codec/Xlsx/Parser/Internal/PivotTable.hs
@@ -11,6 +11,7 @@ import Control.Applicative
 import Data.ByteString.Lazy (ByteString)
 import Data.List (transpose)
 import Data.Maybe (listToMaybe, mapMaybe, maybeToList)
+import Data.Scientific (fromFloatDigits)
 import Data.Text (Text)
 import Safe (atMay)
 import Text.XML
@@ -105,5 +106,5 @@ fillCacheFieldsFromRecords fields recs =
         then field {cfItems = mapMaybe recToCellValue recVals}
         else field
     recToCellValue (CacheText t) = Just $ CellText t
-    recToCellValue (CacheNumber n) = Just $ CellDouble n
+    recToCellValue (CacheNumber n) = Just $ CellDecimal (fromFloatDigits n)
     recToCellValue (CacheIndex _) = Nothing

--- a/src/Codec/Xlsx/Parser/Internal/Util.hs
+++ b/src/Codec/Xlsx/Parser/Internal/Util.hs
@@ -24,7 +24,7 @@ eitherDecimal t = case T.signed T.decimal t of
 rational :: (MonadFail m) => Text -> m Double
 rational = fromEither . eitherRational
 
-eitherRational :: Text -> Either String Double
+eitherRational :: Fractional a => Text -> Either String a
 eitherRational t = case T.signed T.rational t of
   Right (r, leftover) | T.null leftover -> Right r
   _ -> Left $ "invalid rational: " ++ show t

--- a/src/Codec/Xlsx/Parser/Stream.hs
+++ b/src/Codec/Xlsx/Parser/Stream.hs
@@ -526,7 +526,7 @@ parseValue sstrings txt = \case
     string <- maybe (Left $ SharedStringsNotFound idx sstrings) Right $ {-# SCC "sstrings_lookup_scc" #-}  (sstrings ^? ix idx)
     Right $ CellText string
   TStr -> pure $ CellText txt
-  TN -> bimap (ReadError txt) (CellDouble . fst) $ Read.double txt
+  TN -> bimap (ReadError txt) (CellDecimal . fst) $ Read.rational txt
   TE -> bimap (ReadError txt) (CellError . fst) $ fromAttrVal txt
   TB | txt == "1" -> Right $ CellBool True
      | txt == "0" -> Right $ CellBool False

--- a/src/Codec/Xlsx/Types/PivotTable/Internal.hs
+++ b/src/Codec/Xlsx/Types/PivotTable/Internal.hs
@@ -55,7 +55,7 @@ instance FromCursor CacheField where
 cellValueFromNode :: Node -> [CellValue]
 cellValueFromNode n
   | n `nodeElNameIs` (n_ "s") = CellText <$> attributeV
-  | n `nodeElNameIs` (n_ "n") = CellDouble <$> attributeV
+  | n `nodeElNameIs` (n_ "n") = CellDecimal <$> attributeV
   | otherwise = fail "no matching shared item"
   where
     cur = fromNode n

--- a/xlsx.cabal
+++ b/xlsx.cabal
@@ -105,6 +105,7 @@ Library
                    , network-uri
                    , old-locale   >= 1.0.0.5
                    , safe         >= 0.3
+                   , scientific
                    , text         >= 0.11.3.1
                    , time         >= 1.4.0.1
                    , transformers >= 0.3.0.0


### PR DESCRIPTION
The XML contains decimal values, which are accurately represented by `Scientific` but not by `Double` as in the `CellDouble` constructor of `CellValue`. This PR makes `CellDouble` a pattern synonym and replaces the old constructor by a new constuctor `CellDecimal` which holds a `Scientific` value. 
For motivation, see [this issue](https://github.com/qrilka/xlsx/issues/176).