### PR TITLE
Correctly parse shared strings in the streaming implementation

### DIFF
--- a/src/Codec/Xlsx/Parser/Stream.hs
+++ b/src/Codec/Xlsx/Parser/Stream.hs
@@ -41,6 +41,7 @@ module Codec.Xlsx.Parser.Stream
   , WorkbookInfo(..)
   , SheetInfo(..)
   , wiSheets
+  , getOrParseSharedStringss
   , getWorkbookInfo
   , CellRow
   , readSheet
@@ -256,10 +257,10 @@ parseSharedStrings
      )
   => HexpatEvent -> m (Maybe Text)
 parseSharedStrings = \case
-  StartElement "t" _ -> Nothing <$ (ss_string .= mempty)
-  EndElement "t"     -> Just . LT.toStrict . TB.toLazyText <$> gets _ss_string
-  CharacterData txt  -> Nothing <$ (ss_string <>= TB.fromText txt)
-  _                  -> pure Nothing
+  StartElement "si" _ -> Nothing <$ (ss_string .= mempty)
+  EndElement "si"     -> Just . LT.toStrict . TB.toLazyText <$> gets _ss_string
+  CharacterData txt   -> Nothing <$ (ss_string <>= TB.fromText txt)
+  _                   -> pure Nothing
 
 -- | Run a series of actions on an Xlsx file
 runXlsxM :: MonadIO m => FilePath -> XlsxM a -> m a

--- a/src/Codec/Xlsx/Parser/Stream.hs
+++ b/src/Codec/Xlsx/Parser/Stream.hs
@@ -182,6 +182,8 @@ makeLenses 'MkSheetState
 -- | State for parsing shared strings
 data SharedStringsState = MkSharedStringsState
   { _ss_string :: TB.Builder -- ^ String we are parsing
+  -- TODO: At the moment SharedStrings can be used only to create CellText values.
+  -- We should add support for CellRich values.
   , _ss_list   :: DL.DList Text -- ^ list of shared strings
   } deriving stock (Generic, Show)
 makeLenses 'MkSharedStringsState
@@ -257,6 +259,7 @@ parseSharedStrings
      )
   => HexpatEvent -> m (Maybe Text)
 parseSharedStrings = \case
+  -- TODO: Add parsing of text styles to further create CellRich values.
   StartElement "si" _ -> Nothing <$ (ss_string .= mempty)
   EndElement "si"     -> Just . LT.toStrict . TB.toLazyText <$> gets _ss_string
   CharacterData txt   -> Nothing <$ (ss_string <>= TB.fromText txt)

--- a/xlsx.cabal
+++ b/xlsx.cabal
@@ -176,6 +176,7 @@ test-suite data-test
                , conduit
                , filepath
                , deepseq
+               , zip
   if flag(microlens)
     Build-depends:     microlens    >= 0.4 && < 0.5
                      , microlens-mtl


### PR DESCRIPTION
At the moment `Codec.Xlsx.Parser.Stream.parseSharedStrings` implementation incorrectly parses shared strings values:
it creates a separate values for each formatted piece of text. This creates skewed data in the result.

 Here is an example of failing test:
```haskell
textA1 = "Text at A1"
firstClauseB1 = "First clause at B1;"
firstClauseB2 = "First clause at B2;"
secondClauseB1 = "Second clause at B1"
secondClauseB2 = "Second clause at B2"

cellRich :: Text -> Text -> CellValue
cellRich firstClause secondClause = CellRich
  [ RichTextRun
      { _richTextRunProperties = SomeProperties
      , _richTextRunText = firstClause
      }
  , RichTextRun
      { _richTextRunProperties = SomeOtherProperties
      , _richTextRunText = secondClause
      }
  ]

richWorkbook :: Xlsx
richWorkbook = def & atSheet "Sheet1" ?~ toWs
  [ ((RowIndex 1, ColumnIndex 1), cellValue ?~ CellText textA1 $ def)
  , ((RowIndex 2, ColumnIndex 1), cellValue ?~ cellRich firstClauseB1 secondClauseB1 $ def)
  , ((RowIndex 2, ColumnIndex 2), cellValue ?~ cellRich firstClauseB2 secondClauseB2 $ def)
  ]

        Expected:
        fromList
          ["First clause at B1;Second clause at B1",
           "First clause at B2;Second clause at B2", "Text at A1"]
        
        Difference:
        2,3c2,3
        <   ["First clause at B1;Second clause at B1",
        <    "First clause at B2;Second clause at B2", "Text at A1"]
        ---
        >   ["First clause at B1;", "First clause at B2;",
        >    "Second clause at B1", "Second clause at B2", "Text at A1"]
```

This PR fixes this behavior. Now we parse a shared string as a single cell value.

P.S. We still create `CellValue` as _CellText_, not as _CellRich_. 