### PR TITLE
Fix build failure with new xml-conduit release

### DIFF
--- a/src/Codec/Xlsx/Writer/Stream.hs
+++ b/src/Codec/Xlsx/Writer/Stream.hs
@@ -71,7 +71,9 @@ import Text.Printf
 import Text.XML (toXMLElement)
 import qualified Text.XML as TXML
 import Text.XML.Stream.Render
+#if MIN_VERSION_xml_conduit(1,10,0)
 import Text.XML.Stream.Render.Internal (RenderSettings(rsPretty))
+#endif
 import Text.XML.Unresolved (elementToEvents)
 
 

--- a/src/Codec/Xlsx/Writer/Stream.hs
+++ b/src/Codec/Xlsx/Writer/Stream.hs
@@ -71,9 +71,6 @@ import Text.Printf
 import Text.XML (toXMLElement)
 import qualified Text.XML as TXML
 import Text.XML.Stream.Render
-#if MIN_VERSION_xml_conduit(1,10,0)
-import Text.XML.Stream.Render.Internal (RenderSettings(rsPretty))
-#endif
 import Text.XML.Unresolved (elementToEvents)
 
 
@@ -268,7 +265,7 @@ writeSst sharedStrings' = doc (n_ "sst") $
                   ) $ sortBy (\(_, i) (_, y :: Int) -> compare i y) $ Map.toList sharedStrings'
 
 writeEvents ::  PrimMonad m => ConduitT Event Builder m ()
-writeEvents = renderBuilder (def {rsPretty=False})
+writeEvents = renderBuilder def
 
 sheetViews :: forall m . MonadReader SheetWriteSettings m => forall i . ConduitT i Event m ()
 sheetViews = do

--- a/src/Codec/Xlsx/Writer/Stream.hs
+++ b/src/Codec/Xlsx/Writer/Stream.hs
@@ -71,6 +71,7 @@ import Text.Printf
 import Text.XML (toXMLElement)
 import qualified Text.XML as TXML
 import Text.XML.Stream.Render
+import Text.XML.Stream.Render.Internal (RenderSettings(rsPretty))
 import Text.XML.Unresolved (elementToEvents)
 
 


### PR DESCRIPTION
With the latest release of xml-conduit, `RenderSettings` have been moved to an `Internal` module. Therefore, the building the package fails. It needs to import `rsPretty` from it's new home.