### PR TITLE
workbook: remove n prefix

### DIFF
--- a/src/Codec/Xlsx/Parser/Internal.hs
+++ b/src/Codec/Xlsx/Parser/Internal.hs
@@ -7,6 +7,7 @@
 module Codec.Xlsx.Parser.Internal
   ( ParseException(..)
   , n_
+  , addSmlNamespace
   , nodeElNameIs
   , FromCursor(..)
   , FromAttrVal(..)
@@ -38,6 +39,7 @@ import GHC.Generics (Generic)
 import Text.XML
 import Text.XML.Cursor
 
+import Codec.Xlsx.Writer.Internal
 import Codec.Xlsx.Parser.Internal.Fast
 import Codec.Xlsx.Parser.Internal.Util
 
@@ -146,10 +148,15 @@ runReader reader t = case reader t of
   Right (r, leftover) | T.null leftover -> [r]
   _ -> []
 
--- | Add sml namespace to name
+
+{-# DEPRECATED n_ "Renamed to addSmlNamespace" #-}
 n_ :: Text -> Name
-n_ x = Name
+n_ = addSmlNamespace
+
+-- | Add sml namespace to name
+addSmlNamespace :: Text -> Name
+addSmlNamespace x = Name
   { nameLocalName = x
-  , nameNamespace = Just "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+  , nameNamespace = Just mainNamespace
   , namePrefix = Nothing
   }

--- a/src/Codec/Xlsx/Parser/Internal/PivotTable.hs
+++ b/src/Codec/Xlsx/Parser/Internal/PivotTable.hs
@@ -37,19 +37,19 @@ parsePivotTable srcByCacheId bs =
         Just (_pvtSrcSheet, _pvtSrcRef, cacheFields) -> do
           _pvtDataCaption <- attribute "dataCaption" cur
           _pvtName <- attribute "name" cur
-          _pvtLocation <- cur $/ element (n_ "location") >=> fromAttribute "ref"
+          _pvtLocation <- cur $/ element (addSmlNamespace "location") >=> fromAttribute "ref"
           _pvtRowGrandTotals <- fromAttributeDef "rowGrandTotals" True cur
           _pvtColumnGrandTotals <- fromAttributeDef "colGrandTotals" True cur
           _pvtOutline <- fromAttributeDef "outline" False cur
           _pvtOutlineData <- fromAttributeDef "outlineData" False cur
           let pvtFieldsWithHidden =
-                cur $/ element (n_ "pivotFields") &/ element (n_ "pivotField") >=> \c -> do
+                cur $/ element (addSmlNamespace "pivotFields") &/ element (addSmlNamespace "pivotField") >=> \c -> do
                   -- actually gets overwritten from cache to have consistent field names
                   _pfiName <- maybeAttribute "name" c
                   _pfiSortType <- fromAttributeDef "sortType" FieldSortManual c
                   _pfiOutline <- fromAttributeDef "outline" True c
                   let hidden =
-                        c $/ element (n_ "items") &/ element (n_ "item") >=>
+                        c $/ element (addSmlNamespace "items") &/ element (addSmlNamespace "item") >=>
                         attrValIs "h" True >=> fromAttribute "x"
                       _pfiHiddenItems = []
                   return (PivotFieldInfo {..}, hidden)
@@ -64,13 +64,13 @@ parsePivotTable srcByCacheId bs =
               nToFieldName = zip [0 ..] $ map cfName cacheFields
               fieldNameList fld = maybeToList $ lookup fld nToFieldName
               _pvtRowFields =
-                cur $/ element (n_ "rowFields") &/ element (n_ "field") >=>
+                cur $/ element (addSmlNamespace "rowFields") &/ element (addSmlNamespace "field") >=>
                 fromAttribute "x" >=> fieldPosition
               _pvtColumnFields =
-                cur $/ element (n_ "colFields") &/ element (n_ "field") >=>
+                cur $/ element (addSmlNamespace "colFields") &/ element (addSmlNamespace "field") >=>
                 fromAttribute "x" >=> fieldPosition
               _pvtDataFields =
-                cur $/ element (n_ "dataFields") &/ element (n_ "dataField") >=> \c -> do
+                cur $/ element (addSmlNamespace "dataFields") &/ element (addSmlNamespace "dataField") >=> \c -> do
                   fld <- fromAttribute "fld" c
                   _dfField <- fieldNameList fld
                   -- TOFIX
@@ -89,10 +89,10 @@ parseCache bs = listToMaybe . parse . fromDocument $ parseLBS_ def bs
     parse cur = do
       refId <- maybeAttribute (odr "id") cur
       (sheet, ref) <-
-        cur $/ element (n_ "cacheSource") &/ element (n_ "worksheetSource") >=>
+        cur $/ element (addSmlNamespace "cacheSource") &/ element (addSmlNamespace "worksheetSource") >=>
         liftA2 (,) <$> attribute "sheet" <*> fromAttribute "ref"
       let fields =
-            cur $/ element (n_ "cacheFields") &/ element (n_ "cacheField") >=>
+            cur $/ element (addSmlNamespace "cacheFields") &/ element (addSmlNamespace "cacheField") >=>
             fromCursor
       return (sheet, ref, fields, refId)
 

--- a/src/Codec/Xlsx/Types/Common.hs
+++ b/src/Codec/Xlsx/Types/Common.hs
@@ -548,8 +548,8 @@ dateToNumber b (UTCTime day diffTime) = numberOfDays + fractionOfOneDay
 instance FromCursor XlsxText where
   fromCursor cur = do
     let
-      ts = cur $/ element (n_ "t") >=> contentOrEmpty
-      rs = cur $/ element (n_ "r") >=> fromCursor
+      ts = cur $/ element (addSmlNamespace "t") >=> contentOrEmpty
+      rs = cur $/ element (addSmlNamespace "r") >=> fromCursor
     case (ts,rs) of
       ([t], []) ->
         return $ XlsxText t

--- a/src/Codec/Xlsx/Types/ConditionalFormatting.hs
+++ b/src/Codec/Xlsx/Types/ConditionalFormatting.hs
@@ -417,8 +417,8 @@ readCondition "beginsWith" cur = do
   txt <- fromAttribute "text" cur
   return $ BeginsWith txt
 readCondition "colorScale" cur = do
-  let cfvos = cur $/ element (n_ "colorScale") &/ element (n_ "cfvo") &| node
-      colors = cur $/ element (n_ "colorScale") &/ element (n_ "color") &| node
+  let cfvos = cur $/ element (addSmlNamespace "colorScale") &/ element (addSmlNamespace "cfvo") &| node
+      colors = cur $/ element (addSmlNamespace "colorScale") &/ element (addSmlNamespace "color") &| node
   case (cfvos, colors) of
     ([n1, n2], [cn1, cn2]) -> do
       mincfv <- fromCursor $ fromNode n1
@@ -438,7 +438,7 @@ readCondition "colorScale" cur = do
       error "Malformed colorScale condition"
 readCondition "cellIs" cur           = do
     operator <- fromAttribute "operator" cur
-    let formulas = cur $/ element (n_ "formula") >=> fromCursor
+    let formulas = cur $/ element (addSmlNamespace "formula") >=> fromCursor
     expr <- readOpExpression operator formulas
     return $ CellIs expr
 readCondition "containsBlanks" _     = return ContainsBlanks
@@ -446,15 +446,15 @@ readCondition "containsErrors" _     = return ContainsErrors
 readCondition "containsText" cur     = do
     txt <- fromAttribute "text" cur
     return $ ContainsText txt
-readCondition "dataBar" cur = fmap DataBar $ cur $/ element (n_ "dataBar") >=> fromCursor
+readCondition "dataBar" cur = fmap DataBar $ cur $/ element (addSmlNamespace "dataBar") >=> fromCursor
 readCondition "duplicateValues" _    = return DuplicateValues
 readCondition "endsWith" cur         = do
     txt <- fromAttribute "text" cur
     return $ EndsWith txt
 readCondition "expression" cur       = do
-    formula <- cur $/ element (n_ "formula") >=> fromCursor
+    formula <- cur $/ element (addSmlNamespace "formula") >=> fromCursor
     return $ Expression formula
-readCondition "iconSet" cur = fmap IconSet $ cur $/ element (n_ "iconSet") >=> fromCursor
+readCondition "iconSet" cur = fmap IconSet $ cur $/ element (addSmlNamespace "iconSet") >=> fromCursor
 readCondition "notContainsBlanks" _  = return DoesNotContainBlanks
 readCondition "notContainsErrors" _  = return DoesNotContainErrors
 readCondition "notContainsText" cur  = do
@@ -702,7 +702,7 @@ defaultIconSet =  IconSet3TrafficLights1
 instance FromCursor IconSetOptions where
   fromCursor cur = do
     _isoIconSet <- fromAttributeDef "iconSet" defaultIconSet cur
-    let _isoValues = cur $/ element (n_ "cfvo") >=> fromCursor
+    let _isoValues = cur $/ element (addSmlNamespace "cfvo") >=> fromCursor
     _isoReverse <- fromAttributeDef "reverse" False cur
     _isoShowValue <- fromAttributeDef "showValue" True cur
     return IconSetOptions {..}
@@ -761,12 +761,12 @@ instance FromCursor DataBarOptions where
     _dboMaxLength <- fromAttributeDef "maxLength" defaultDboMaxLength cur
     _dboMinLength <- fromAttributeDef "minLength" defaultDboMinLength cur
     _dboShowValue <- fromAttributeDef "showValue" True cur
-    let cfvos = cur $/ element (n_ "cfvo") &| node
+    let cfvos = cur $/ element (addSmlNamespace "cfvo") &| node
     case cfvos of
       [nMin, nMax] -> do
         _dboMinimum <- fromCursor (fromNode nMin)
         _dboMaximum <- fromCursor (fromNode nMax)
-        _dboColor <- cur $/ element (n_ "color") >=> fromCursor
+        _dboColor <- cur $/ element (addSmlNamespace "color") >=> fromCursor
         return DataBarOptions{..}
       ns -> do
         fail $ "expected minimum and maximum cfvo nodes but see instead " ++

--- a/src/Codec/Xlsx/Types/DataValidation.hs
+++ b/src/Codec/Xlsx/Types/DataValidation.hs
@@ -213,7 +213,7 @@ readValidationType _ "custom" cur = do
     f <- fromCursor cur
     return $ ValidationTypeCustom f
 readValidationType _ "list" cur = do
-    f  <- cur $/ element (n_ "formula1") >=> fromCursor
+    f  <- cur $/ element (addSmlNamespace "formula1") >=> fromCursor
     as <- maybeToList $ readListFormulas f
     return $ ValidationTypeList as
 readValidationType op ty cur = do
@@ -257,11 +257,11 @@ readListFormulas (Formula f) = readQuotedList f <|> readUnquotedCellRange f
 readOpExpression2 :: Text -> Cursor -> [ValidationExpression]
 readOpExpression2 op cur
     | op `elem` ["between", "notBetween"] = do
-        f1 <- cur $/ element (n_ "formula1") >=> fromCursor
-        f2 <- cur $/ element (n_ "formula2") >=> fromCursor
+        f1 <- cur $/ element (addSmlNamespace "formula1") >=> fromCursor
+        f2 <- cur $/ element (addSmlNamespace "formula2") >=> fromCursor
         readValExpression op [f1,f2]
 readOpExpression2 op cur = do
-    f <- cur $/ element (n_ "formula1") >=> fromCursor
+    f <- cur $/ element (addSmlNamespace "formula1") >=> fromCursor
     readValExpression op [f]
 
 readValidationTypeOpExp :: Text -> ValidationExpression -> [ValidationType]

--- a/src/Codec/Xlsx/Types/Internal/CfPair.hs
+++ b/src/Codec/Xlsx/Types/Internal/CfPair.hs
@@ -22,7 +22,7 @@ newtype CfPair = CfPair
 instance FromCursor CfPair where
     fromCursor cur = do
         sqref <- fromAttribute "sqref" cur
-        let cfRules = cur $/ element (n_ "cfRule") >=> fromCursor
+        let cfRules = cur $/ element (addSmlNamespace "cfRule") >=> fromCursor
         return $ CfPair (sqref, cfRules)
 
 instance FromXenoNode CfPair where

--- a/src/Codec/Xlsx/Types/Internal/CommentTable.hs
+++ b/src/Codec/Xlsx/Types/Internal/CommentTable.hs
@@ -68,15 +68,15 @@ instance ToElement CommentTable where
 
 instance FromCursor CommentTable where
   fromCursor cur = do
-    let authorNames = cur $/ element (n_ "authors") &/ element (n_ "author") >=> contentOrEmpty
+    let authorNames = cur $/ element (addSmlNamespace "authors") &/ element (addSmlNamespace "author") >=> contentOrEmpty
         authors = M.fromList $ zip [0..] authorNames
-        items = cur $/ element (n_ "commentList") &/ element (n_ "comment") >=> parseComment authors
+        items = cur $/ element (addSmlNamespace "commentList") &/ element (addSmlNamespace "comment") >=> parseComment authors
     return . CommentTable $ M.fromList items
 
 parseComment :: Map Int Text -> Cursor -> [(CellRef, Comment)]
 parseComment authors cur = do
     ref <- fromAttribute "ref" cur
-    txt <- cur $/ element (n_ "text") >=> fromCursor
+    txt <- cur $/ element (addSmlNamespace "text") >=> fromCursor
     authorId <- cur $| attribute "authorId" >=> decimal
     visible <- (read . Text.unpack :: Text -> Bool)
       <$> (fromAttribute "visible" cur :: [Text])

--- a/src/Codec/Xlsx/Types/Internal/SharedStringTable.hs
+++ b/src/Codec/Xlsx/Types/Internal/SharedStringTable.hs
@@ -82,7 +82,7 @@ instance ToElement SharedStringTable where
 instance FromCursor SharedStringTable where
   fromCursor cur = do
     let
-      items = cur $/ element (n_ "si") >=> fromCursor
+      items = cur $/ element (addSmlNamespace "si") >=> fromCursor
     return (SharedStringTable (V.fromList items))
 
 {-------------------------------------------------------------------------------

--- a/src/Codec/Xlsx/Types/PivotTable/Internal.hs
+++ b/src/Codec/Xlsx/Types/PivotTable/Internal.hs
@@ -48,14 +48,14 @@ instance FromCursor CacheField where
   fromCursor cur = do
     cfName <- fromAttribute "name" cur
     let cfItems =
-          cur $/ element (n_ "sharedItems") &/ anyElement >=>
+          cur $/ element (addSmlNamespace "sharedItems") &/ anyElement >=>
           cellValueFromNode . node
     return CacheField {..}
 
 cellValueFromNode :: Node -> [CellValue]
 cellValueFromNode n
-  | n `nodeElNameIs` (n_ "s") = CellText <$> attributeV
-  | n `nodeElNameIs` (n_ "n") = CellDouble <$> attributeV
+  | n `nodeElNameIs` (addSmlNamespace "s") = CellText <$> attributeV
+  | n `nodeElNameIs` (addSmlNamespace "n") = CellDouble <$> attributeV
   | otherwise = fail "no matching shared item"
   where
     cur = fromNode n
@@ -64,9 +64,9 @@ cellValueFromNode n
 
 recordValueFromNode :: Node -> [CacheRecordValue]
 recordValueFromNode n
-  | n `nodeElNameIs` (n_ "s") = CacheText <$> attributeV
-  | n `nodeElNameIs` (n_ "n") = CacheNumber <$> attributeV
-  | n `nodeElNameIs` (n_ "x") = CacheIndex <$> attributeV
+  | n `nodeElNameIs` (addSmlNamespace "s") = CacheText <$> attributeV
+  | n `nodeElNameIs` (addSmlNamespace "n") = CacheNumber <$> attributeV
+  | n `nodeElNameIs` (addSmlNamespace "x") = CacheIndex <$> attributeV
   | otherwise = fail "not valid cache record value"
   where
     cur = fromNode n

--- a/src/Codec/Xlsx/Types/RichText.hs
+++ b/src/Codec/Xlsx/Types/RichText.hs
@@ -263,8 +263,8 @@ instance ToElement RunProperties where
 -- | See @CT_RElt@, p. 3903
 instance FromCursor RichTextRun where
   fromCursor cur = do
-    _richTextRunText <- cur $/ element (n_ "t") &/ content
-    _richTextRunProperties <- maybeFromElement (n_ "rPr") cur
+    _richTextRunText <- cur $/ element (addSmlNamespace "t") &/ content
+    _richTextRunProperties <- maybeFromElement (addSmlNamespace "rPr") cur
     return RichTextRun{..}
 
 instance FromXenoNode RichTextRun where
@@ -277,21 +277,21 @@ instance FromXenoNode RichTextRun where
 -- | See @CT_RPrElt@, p. 3903
 instance FromCursor RunProperties where
   fromCursor cur = do
-    _runPropertiesFont          <- maybeElementValue (n_ "rFont") cur
-    _runPropertiesCharset       <- maybeElementValue (n_ "charset") cur
-    _runPropertiesFontFamily    <- maybeElementValue (n_ "family") cur
-    _runPropertiesBold          <- maybeBoolElementValue (n_ "b") cur
-    _runPropertiesItalic        <- maybeBoolElementValue (n_ "i") cur
-    _runPropertiesStrikeThrough <- maybeBoolElementValue (n_ "strike") cur
-    _runPropertiesOutline       <- maybeBoolElementValue (n_ "outline") cur
-    _runPropertiesShadow        <- maybeBoolElementValue (n_ "shadow") cur
-    _runPropertiesCondense      <- maybeBoolElementValue (n_ "condense") cur
-    _runPropertiesExtend        <- maybeBoolElementValue (n_ "extend") cur
-    _runPropertiesColor         <- maybeFromElement  (n_ "color") cur
-    _runPropertiesSize          <- maybeElementValue (n_ "sz") cur
-    _runPropertiesUnderline     <- maybeElementValueDef (n_ "u") FontUnderlineSingle cur
-    _runPropertiesVertAlign     <- maybeElementValue (n_ "vertAlign") cur
-    _runPropertiesScheme        <- maybeElementValue (n_ "scheme") cur
+    _runPropertiesFont          <- maybeElementValue (addSmlNamespace "rFont") cur
+    _runPropertiesCharset       <- maybeElementValue (addSmlNamespace "charset") cur
+    _runPropertiesFontFamily    <- maybeElementValue (addSmlNamespace "family") cur
+    _runPropertiesBold          <- maybeBoolElementValue (addSmlNamespace "b") cur
+    _runPropertiesItalic        <- maybeBoolElementValue (addSmlNamespace "i") cur
+    _runPropertiesStrikeThrough <- maybeBoolElementValue (addSmlNamespace "strike") cur
+    _runPropertiesOutline       <- maybeBoolElementValue (addSmlNamespace "outline") cur
+    _runPropertiesShadow        <- maybeBoolElementValue (addSmlNamespace "shadow") cur
+    _runPropertiesCondense      <- maybeBoolElementValue (addSmlNamespace "condense") cur
+    _runPropertiesExtend        <- maybeBoolElementValue (addSmlNamespace "extend") cur
+    _runPropertiesColor         <- maybeFromElement  (addSmlNamespace "color") cur
+    _runPropertiesSize          <- maybeElementValue (addSmlNamespace "sz") cur
+    _runPropertiesUnderline     <- maybeElementValueDef (addSmlNamespace "u") FontUnderlineSingle cur
+    _runPropertiesVertAlign     <- maybeElementValue (addSmlNamespace "vertAlign") cur
+    _runPropertiesScheme        <- maybeElementValue (addSmlNamespace "scheme") cur
     return RunProperties{..}
 
 instance FromXenoNode RunProperties where

--- a/src/Codec/Xlsx/Types/SheetViews.hs
+++ b/src/Codec/Xlsx/Types/SheetViews.hs
@@ -471,8 +471,8 @@ instance FromCursor SheetView where
     _sheetViewZoomScaleSheetLayoutView <- maybeAttribute "zoomScaleSheetLayoutView" cur
     _sheetViewZoomScalePageLayoutView  <- maybeAttribute "zoomScalePageLayoutView" cur
     _sheetViewWorkbookViewId           <- fromAttribute "workbookViewId" cur
-    let _sheetViewPane = listToMaybe $ cur $/ element (n_ "pane") >=> fromCursor
-        _sheetViewSelection = cur $/ element (n_ "selection") >=> fromCursor
+    let _sheetViewPane = listToMaybe $ cur $/ element (addSmlNamespace "pane") >=> fromCursor
+        _sheetViewSelection = cur $/ element (addSmlNamespace "selection") >=> fromCursor
     return SheetView{..}
 
 instance FromXenoNode SheetView where

--- a/src/Codec/Xlsx/Types/StyleSheet.hs
+++ b/src/Codec/Xlsx/Types/StyleSheet.hs
@@ -1430,15 +1430,15 @@ instance ToAttrVal ReadingOrder where
 instance FromCursor StyleSheet where
   fromCursor cur = do
     let
-      _styleSheetFonts = cur $/ element (n_ "fonts") &/ element (n_ "font") >=> fromCursor
-      _styleSheetFills = cur $/ element (n_ "fills") &/ element (n_ "fill") >=> fromCursor
-      _styleSheetBorders = cur $/ element (n_ "borders") &/ element (n_ "border") >=> fromCursor
+      _styleSheetFonts = cur $/ element (addSmlNamespace "fonts") &/ element (addSmlNamespace "font") >=> fromCursor
+      _styleSheetFills = cur $/ element (addSmlNamespace "fills") &/ element (addSmlNamespace "fill") >=> fromCursor
+      _styleSheetBorders = cur $/ element (addSmlNamespace "borders") &/ element (addSmlNamespace "border") >=> fromCursor
          -- TODO: cellStyleXfs
-      _styleSheetCellXfs = cur $/ element (n_ "cellXfs") &/ element (n_ "xf") >=> fromCursor
+      _styleSheetCellXfs = cur $/ element (addSmlNamespace "cellXfs") &/ element (addSmlNamespace "xf") >=> fromCursor
          -- TODO: cellStyles
-      _styleSheetDxfs = cur $/ element (n_ "dxfs") &/ element (n_ "dxf") >=> fromCursor
+      _styleSheetDxfs = cur $/ element (addSmlNamespace "dxfs") &/ element (addSmlNamespace "dxf") >=> fromCursor
       _styleSheetNumFmts = M.fromList . map mkNumFmtPair $
-          cur $/ element (n_ "numFmts")&/ element (n_ "numFmt") >=> fromCursor
+          cur $/ element (addSmlNamespace "numFmts")&/ element (addSmlNamespace "numFmt") >=> fromCursor
          -- TODO: tableStyles
          -- TODO: colors
          -- TODO: extLst
@@ -1447,21 +1447,21 @@ instance FromCursor StyleSheet where
 -- | See @CT_Font@, p. 4489
 instance FromCursor Font where
   fromCursor cur = do
-    _fontName         <- maybeElementValue (n_ "name") cur
-    _fontCharset      <- maybeElementValue (n_ "charset") cur
-    _fontFamily       <- maybeElementValue (n_ "family") cur
-    _fontBold         <- maybeBoolElementValue (n_ "b") cur
-    _fontItalic       <- maybeBoolElementValue (n_ "i") cur
-    _fontStrikeThrough<- maybeBoolElementValue (n_ "strike") cur
-    _fontOutline      <- maybeBoolElementValue (n_ "outline") cur
-    _fontShadow       <- maybeBoolElementValue (n_ "shadow") cur
-    _fontCondense     <- maybeBoolElementValue (n_ "condense") cur
-    _fontExtend       <- maybeBoolElementValue (n_ "extend") cur
-    _fontColor        <- maybeFromElement  (n_ "color") cur
-    _fontSize         <- maybeElementValue (n_ "sz") cur
-    _fontUnderline    <- maybeElementValueDef (n_ "u") FontUnderlineSingle cur
-    _fontVertAlign    <- maybeElementValue (n_ "vertAlign") cur
-    _fontScheme       <- maybeElementValue (n_ "scheme") cur
+    _fontName         <- maybeElementValue (addSmlNamespace "name") cur
+    _fontCharset      <- maybeElementValue (addSmlNamespace "charset") cur
+    _fontFamily       <- maybeElementValue (addSmlNamespace "family") cur
+    _fontBold         <- maybeBoolElementValue (addSmlNamespace "b") cur
+    _fontItalic       <- maybeBoolElementValue (addSmlNamespace "i") cur
+    _fontStrikeThrough<- maybeBoolElementValue (addSmlNamespace "strike") cur
+    _fontOutline      <- maybeBoolElementValue (addSmlNamespace "outline") cur
+    _fontShadow       <- maybeBoolElementValue (addSmlNamespace "shadow") cur
+    _fontCondense     <- maybeBoolElementValue (addSmlNamespace "condense") cur
+    _fontExtend       <- maybeBoolElementValue (addSmlNamespace "extend") cur
+    _fontColor        <- maybeFromElement  (addSmlNamespace "color") cur
+    _fontSize         <- maybeElementValue (addSmlNamespace "sz") cur
+    _fontUnderline    <- maybeElementValueDef (addSmlNamespace "u") FontUnderlineSingle cur
+    _fontVertAlign    <- maybeElementValue (addSmlNamespace "vertAlign") cur
+    _fontScheme       <- maybeElementValue (addSmlNamespace "scheme") cur
     return Font{..}
 
 -- | See 18.18.94 "ST_FontFamily (Font Family)" (p. 2517)
@@ -1545,15 +1545,15 @@ instance FromAttrBs FontScheme where
 -- | See @CT_Fill@, p. 4484
 instance FromCursor Fill where
   fromCursor cur = do
-    _fillPattern <- maybeFromElement (n_ "patternFill") cur
+    _fillPattern <- maybeFromElement (addSmlNamespace "patternFill") cur
     return Fill{..}
 
 -- | See @CT_PatternFill@, p. 4484
 instance FromCursor FillPattern where
   fromCursor cur = do
     _fillPatternType <- maybeAttribute "patternType" cur
-    _fillPatternFgColor <- maybeFromElement (n_ "fgColor") cur
-    _fillPatternBgColor <- maybeFromElement (n_ "bgColor") cur
+    _fillPatternFgColor <- maybeFromElement (addSmlNamespace "fgColor") cur
+    _fillPatternBgColor <- maybeFromElement (addSmlNamespace "bgColor") cur
     return FillPattern{..}
 
 instance FromAttrVal PatternType where
@@ -1584,21 +1584,21 @@ instance FromCursor Border where
     _borderDiagonalUp   <- maybeAttribute "diagonalUp" cur
     _borderDiagonalDown <- maybeAttribute "diagonalDown" cur
     _borderOutline      <- maybeAttribute "outline" cur
-    _borderStart      <- maybeFromElement (n_ "start") cur
-    _borderEnd        <- maybeFromElement (n_ "end") cur
-    _borderLeft       <- maybeFromElement (n_ "left") cur
-    _borderRight      <- maybeFromElement (n_ "right") cur
-    _borderTop        <- maybeFromElement (n_ "top") cur
-    _borderBottom     <- maybeFromElement (n_ "bottom") cur
-    _borderDiagonal   <- maybeFromElement (n_ "diagonal") cur
-    _borderVertical   <- maybeFromElement (n_ "vertical") cur
-    _borderHorizontal <- maybeFromElement (n_ "horizontal") cur
+    _borderStart      <- maybeFromElement (addSmlNamespace "start") cur
+    _borderEnd        <- maybeFromElement (addSmlNamespace "end") cur
+    _borderLeft       <- maybeFromElement (addSmlNamespace "left") cur
+    _borderRight      <- maybeFromElement (addSmlNamespace "right") cur
+    _borderTop        <- maybeFromElement (addSmlNamespace "top") cur
+    _borderBottom     <- maybeFromElement (addSmlNamespace "bottom") cur
+    _borderDiagonal   <- maybeFromElement (addSmlNamespace "diagonal") cur
+    _borderVertical   <- maybeFromElement (addSmlNamespace "vertical") cur
+    _borderHorizontal <- maybeFromElement (addSmlNamespace "horizontal") cur
     return Border{..}
 
 instance FromCursor BorderStyle where
   fromCursor cur = do
     _borderStyleLine  <- maybeAttribute "style" cur
-    _borderStyleColor <- maybeFromElement (n_ "color") cur
+    _borderStyleColor <- maybeFromElement (addSmlNamespace "color") cur
     return BorderStyle{..}
 
 instance FromAttrVal LineStyle where
@@ -1621,8 +1621,8 @@ instance FromAttrVal LineStyle where
 -- | See @CT_Xf@, p. 4486
 instance FromCursor CellXf where
   fromCursor cur = do
-    _cellXfAlignment  <- maybeFromElement (n_ "alignment") cur
-    _cellXfProtection <- maybeFromElement (n_ "protection") cur
+    _cellXfAlignment  <- maybeFromElement (addSmlNamespace "alignment") cur
+    _cellXfProtection <- maybeFromElement (addSmlNamespace "protection") cur
     _cellXfNumFmtId          <- maybeAttribute "numFmtId" cur
     _cellXfFontId            <- maybeAttribute "fontId" cur
     _cellXfFillId            <- maybeAttribute "fillId" cur
@@ -1641,12 +1641,12 @@ instance FromCursor CellXf where
 -- | See @CT_Dxf@, p. 3937
 instance FromCursor Dxf where
     fromCursor cur = do
-      _dxfFont         <- maybeFromElement (n_ "font") cur
-      _dxfNumFmt       <- maybeFromElement (n_ "numFmt") cur
-      _dxfFill         <- maybeFromElement (n_ "fill") cur
-      _dxfAlignment    <- maybeFromElement (n_ "alignment") cur
-      _dxfBorder       <- maybeFromElement (n_ "border") cur
-      _dxfProtection   <- maybeFromElement (n_ "protection") cur
+      _dxfFont         <- maybeFromElement (addSmlNamespace "font") cur
+      _dxfNumFmt       <- maybeFromElement (addSmlNamespace "numFmt") cur
+      _dxfFill         <- maybeFromElement (addSmlNamespace "fill") cur
+      _dxfAlignment    <- maybeFromElement (addSmlNamespace "alignment") cur
+      _dxfBorder       <- maybeFromElement (addSmlNamespace "border") cur
+      _dxfProtection   <- maybeFromElement (addSmlNamespace "protection") cur
       return Dxf{..}
 
 -- | See @CT_NumFmt@, p. 3936

--- a/src/Codec/Xlsx/Types/Table.hs
+++ b/src/Codec/Xlsx/Types/Table.hs
@@ -90,9 +90,9 @@ instance FromCursor Table where
     tblDisplayName <- fromAttribute "displayName" c
     tblName <- maybeAttribute "name" c
     tblRef <- fromAttribute "ref" c
-    tblAutoFilter <- maybeFromElement (n_ "autoFilter") c
+    tblAutoFilter <- maybeFromElement (addSmlNamespace "autoFilter") c
     let tblColumns =
-          c $/ element (n_ "tableColumns") &/ element (n_ "tableColumn") >=>
+          c $/ element (addSmlNamespace "tableColumns") &/ element (addSmlNamespace "tableColumn") >=>
           fmap TableColumn . fromAttribute "name"
     return Table {..}
 

--- a/test/AutoFilterTests.hs
+++ b/test/AutoFilterTests.hs
@@ -21,5 +21,5 @@ tests =
   testGroup
     "Types.AutFilter tests"
     [ testProperty "fromCursor . toElement == id" $ \(autoFilter :: AutoFilter) ->
-        [autoFilter] == fromCursor (cursorFromElement $ toElement (n_ "autoFilter") autoFilter)
+        [autoFilter] == fromCursor (cursorFromElement $ toElement (addSmlNamespace "autoFilter") autoFilter)
     ]

--- a/test/CondFmtTests.hs
+++ b/test/CondFmtTests.hs
@@ -20,5 +20,5 @@ tests =
   testGroup
     "Types.ConditionalFormatting tests"
     [ testProperty "fromCursor . toElement == id" $ \(cFmt :: CfRule) ->
-        [cFmt] == fromCursor (cursorFromElement $ toElement (n_ "cfRule") cFmt)
+        [cFmt] == fromCursor (cursorFromElement $ toElement (addSmlNamespace "cfRule") cFmt)
     ]


### PR DESCRIPTION
Before this PR, the workbook xlsx looks like this:

```
<?xml version="1.0" encoding="UTF-8"?>
<n:workbook xmlns:n="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
   <n:sheets>
      <n:sheet xmlns:ns="http://schemas.openxmlformats.org/officeDocument/2006/relationships" name="Sheet1" sheetId="1" ns:id="rId3" />
   </n:sheets>
</n:workbook>
```

After this PR, it looks like this:
```
<?xml version="1.0" encoding="UTF-8"?>
<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
   <sheets>
      <sheet name="Sheet1" sheetId="1" r:id="rId3" />
   </sheets>
</workbook>
```

There are 2 improvements:
- The `http://schemas.openxmlformats.org/spreadsheetml/2006/main` is no longer nested under the `:n` subspace. Instead its the top level/root schema. 
- For the stream writer: `http://schemas.openxmlformats.org/officeDocument/2006/relationships` is now declared at the start of the xlsx as its nicer to have all schemas at the start. Excel does it the same.