### PR TITLE
Test against GHC 9.10 in CI

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -13,11 +13,8 @@ jobs:
       matrix:
         include:
         - os: ubuntu-latest
-          stack-yaml: stack-lts-20.yaml
+          stack-yaml: stack-lts-21.yaml
           extra-args: "--flag xlsx:microlens"
-        - os: ubuntu-latest
-          stack-yaml: stack-lts-20.yaml # GHC 9.2
-          extra-args: ""
         - os: ubuntu-latest
           stack-yaml: stack-lts-21.yaml # GHC 9.4
           extra-args: ""

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -24,8 +24,11 @@ jobs:
         - os: ubuntu-latest
           stack-yaml: stack-lts-22.yaml # GHC 9.6
           extra-args: ""
-        - os: ubuntu-latest # GHC 9.8
-          stack-yaml: stack-lts-23.yaml
+        - os: ubuntu-latest
+          stack-yaml: stack-lts-23.yaml # GHC 9.8
+          extra-args: ""
+        - os: ubuntu-latest
+          stack-yaml: stack-lts-24.yaml # GHC 9.10
           extra-args: ""
     steps:
       - name: Clone project

--- a/stack-lts-24.yaml
+++ b/stack-lts-24.yaml
@@ -1,0 +1,4 @@
+resolver: lts-24.13
+packages:
+- '.'
+- examples/

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2023-07-07
+resolver: nightly-2025-09-29 # ghc-9.12.2
 packages:
 - '.'
 - examples/

--- a/xlsx.cabal
+++ b/xlsx.cabal
@@ -28,7 +28,7 @@ Maintainer:          qrilka@gmail.com
 
 Category:            Codec
 Build-type:          Simple
-Tested-with:         GHC == 9.2.8, GHC == 9.4.8, GHC == 9.6.6, GHC == 9.8.4
+Tested-with:         GHC == 9.4.8, GHC == 9.6.6, GHC == 9.8.4, GHC == 9.10.3
 Cabal-version:       >=1.10
 
 Flag microlens


### PR DESCRIPTION
Adding a stack config for GHC 9.10 and updating the nightly version as well. I believe it was still pointing to GHC 9.6.