### PR TITLE
monoid of no mappend, monad of no return

### DIFF
--- a/src/Codec/Xlsx/Parser/Internal/Fast.hs
+++ b/src/Codec/Xlsx/Parser/Internal/Fast.hs
@@ -42,7 +42,6 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Unsafe as SU
 import Data.Char (chr)
 import Data.Maybe
-import Data.Monoid ((<>))
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
@@ -76,7 +75,6 @@ instance Alternative ChildCollector where
     either (const $ g ns) Right (f ns)
 
 instance Monad ChildCollector where
-  return = pure
   ChildCollector f >>= g = ChildCollector $ \ns ->
     either Left (\(!ns', f') -> runChildCollector (g f') ns') (f ns)
 
@@ -153,12 +151,11 @@ newtype AttrParser a = AttrParser
   }
 
 instance Monad AttrParser where
-  return a = AttrParser $ \as -> Right (as, a)
   (AttrParser f) >>= g =
     AttrParser $ \as ->
       either Left (\(as', f') -> runAttrParser (g f') as') (f as)
 instance Applicative AttrParser where
-    pure = return
+    pure a = AttrParser $ \as -> Right (as, a)
     (<*>) = ap
 instance Functor AttrParser where
   fmap = liftM

--- a/src/Codec/Xlsx/Types/RichText.hs
+++ b/src/Codec/Xlsx/Types/RichText.hs
@@ -342,6 +342,7 @@ instance Semigroup RunProperties where
 -- override earlier ones.
 instance Monoid RunProperties where
   mempty = def
+#if !(MIN_VERSION_base(4,11,0))
   a `mappend` b = RunProperties {
       _runPropertiesBold          = override _runPropertiesBold
     , _runPropertiesCharset       = override _runPropertiesCharset
@@ -362,6 +363,7 @@ instance Monoid RunProperties where
     where
       override :: (RunProperties -> Maybe x) -> Maybe x
       override f = f b `mplus` f a
+#endif
 
 -- | Apply properties to a 'RichTextRun'
 --


### PR DESCRIPTION
cf. https://github.com/haskell/core-libraries-committee/issues/418

this applies the changes from https://gist.github.com/L0neGamer/3df4008fd458030cf3cf2c374ccfa3ec

tested on 9.14.1, passes `cabal build && cabal test`